### PR TITLE
feat: extend prepare-node-script to include Juju wiring

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -66,8 +66,6 @@ jobs:
           export COLUMNS=256
           sudo snap install ${{ needs.build-amd64.outputs.snap }} --dangerous
           maas-anvil prepare-node-script | bash -x
-          sudo snap connect maas-anvil:juju-bin juju:juju-bin
-          sudo snap connect maas-anvil:dot-local-share-juju
           sg snap_daemon "maas-anvil -v cluster bootstrap --role database --role region --role agent --role haproxy --accept-defaults"
       - name: Collect juju status
         if: always()
@@ -96,8 +94,6 @@ jobs:
   #         export COLUMNS=256
   #         sudo snap install ${{ needs.build-arm64.outputs.snap }} --dangerous
   #         maas-anvil prepare-node-script | bash -x
-  #         sudo snap connect maas-anvil:juju-bin juju:juju-bin
-  #         sudo snap connect maas-anvil:dot-local-share-juju
   #         sg snap_daemon "maas-anvil -v cluster bootstrap --role database --role region --role agent --role haproxy --accept-defaults"
   #     - name: Collect juju status
   #       if: always()

--- a/anvil-python/anvil/commands/prepare_node.py
+++ b/anvil-python/anvil/commands/prepare_node.py
@@ -73,6 +73,12 @@ sudo snap install --channel {JUJU_CHANNEL} juju
 # Workaround a bug between snapd and juju
 mkdir -p $HOME/.local/share
 mkdir -p $HOME/.config/anvil
+
+# Connect snap to the Juju snap interface and provide access to Juju directory.
+# These actions will allow anvil bootstrap Juju controller and manage the
+# Juju model.
+sudo snap connect maas-anvil:juju-bin juju:juju-bin
+sudo snap connect maas-anvil:dot-local-share-juju
 """
 
 


### PR DESCRIPTION
This PR simplifies the initialization process of Anvil by including the commands that wire Juju into the `prepare-node-script`.