### PR TITLE
feat: introduce pgbouncer as a PostgreSQL proxy

### DIFF
--- a/anvil-python/anvil/versions.py
+++ b/anvil-python/anvil/versions.py
@@ -15,7 +15,8 @@
 
 MAAS_REGION_CHANNEL = "latest/edge"
 MAAS_AGENT_CHANNEL = "latest/edge"
-POSTGRESQL_CHANNEL = "14/stable"
+POSTGRESQL_CHANNEL = "14/candidate"
+PGBOUNCER_CHANNEL = "1/candidate"
 HAPROXY_CHANNEL = "latest/stable"
 
 MACHINE_CHARMS = {
@@ -23,6 +24,7 @@ MACHINE_CHARMS = {
     "maas-agent": MAAS_AGENT_CHANNEL,
     "haproxy": HAPROXY_CHANNEL,
     "postgresql": POSTGRESQL_CHANNEL,
+    "pgbouncer": PGBOUNCER_CHANNEL,
 }
 K8S_CHARMS: dict[str, str] = {}
 
@@ -43,7 +45,12 @@ DEPLOY_MAAS_REGION_TFVAR_MAP = {
             "channel": "charm_maas_region_channel",
             "revision": "charm_maas_region_revision",
             "config": "charm_maas_region_config",
-        }
+        },
+        "pgbouncer": {
+            "channel": "charm_pgbouncer_channel",
+            "revision": "charm_pgbouncer_revision",
+            "config": "charm_pgbouncer_config",
+        },
     }
 }
 

--- a/cloud/etc/deploy-maas-agent/main.tf
+++ b/cloud/etc/deploy-maas-agent/main.tf
@@ -45,7 +45,7 @@ resource "juju_application" "maas-agent" {
   config = var.charm_maas_agent_config
 }
 
-resource "juju_integration" "maas-region-postgresql" {
+resource "juju_integration" "maas-agent-region" {
   model = data.juju_model.machine_model.name
 
   application {

--- a/cloud/etc/deploy-maas-region/main.tf
+++ b/cloud/etc/deploy-maas-region/main.tf
@@ -59,7 +59,7 @@ resource "juju_application" "pgbouncer" {
 
   config = merge({
     pool_mode          = "transaction"
-    max_db_connections = floor(90 / length(var.machine_ids))
+    max_db_connections = floor(90 / max(length(var.machine_ids), 1))
   }, var.charm_pgbouncer_config)
 }
 

--- a/cloud/etc/deploy-maas-region/main.tf
+++ b/cloud/etc/deploy-maas-region/main.tf
@@ -45,7 +45,39 @@ resource "juju_application" "maas-region" {
   config = var.charm_maas_region_config
 }
 
-resource "juju_integration" "maas-region-postgresql" {
+resource "juju_application" "pgbouncer" {
+  name  = "pgbouncer"
+  model = data.juju_model.machine_model.name
+  units = 0 # it is a subordinate charm
+
+  charm {
+    name     = "pgbouncer"
+    channel  = var.charm_pgbouncer_channel
+    revision = var.charm_pgbouncer_revision
+    base     = "ubuntu@22.04"
+  }
+
+  config = merge({
+    pool_mode          = "transaction"
+    max_db_connections = floor(90 / length(var.machine_ids))
+  }, var.charm_pgbouncer_config)
+}
+
+resource "juju_integration" "postgresql-pgbouncer" {
+  model = data.juju_model.machine_model.name
+
+  application {
+    name     = "postgresql"
+    endpoint = "database"
+  }
+
+  application {
+    name     = juju_application.pgbouncer.name
+    endpoint = "backend-database"
+  }
+}
+
+resource "juju_integration" "maas-region-pgbouncer" {
   model = data.juju_model.machine_model.name
 
   application {
@@ -54,7 +86,7 @@ resource "juju_integration" "maas-region-postgresql" {
   }
 
   application {
-    name     = "postgresql"
+    name     = juju_application.pgbouncer.name
     endpoint = "database"
   }
 }

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -47,3 +47,21 @@ variable "enable_haproxy" {
   type        = bool
   default     = false
 }
+
+variable "charm_pgbouncer_channel" {
+  description = "Operator channel for PgBouncer deployment"
+  type        = string
+  default     = "1/candidate"
+}
+
+variable "charm_pgbouncer_revision" {
+  description = "Operator channel revision for PgBouncer deployment"
+  type        = number
+  default     = null
+}
+
+variable "charm_pgbouncer_config" {
+  description = "Operator config for PgBouncer deployment"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This PR adds pgbouncer charm as a subordinate charm of maas-region. Instead of directly communicating with PostgreSQL, MAAS region will use pgbouncer as a proxy. The number of max connections to pgbouncer is configured as relevant to the number of MAAS region nodes of Anvil cluster.

This PR is an enabler for fixing: #11, if not a complete fix at all. In case the default sane values that this PR uses are not enough to fix the starvation issue, the way pgbouncer is introduced, provides a way to override their values. Those overridden values can be passed to pgbouncer through the `manifest` mechanism of maas-anvil.