### PR TITLE
bug: remove sunbeam leftovers

### DIFF
--- a/anvil-python/anvil/commands/inspect.py
+++ b/anvil-python/anvil/commands/inspect.py
@@ -24,13 +24,14 @@ import click
 from rich.console import Console
 from snaphelpers import Snap
 from sunbeam.commands.juju import WriteCharmLogStep, WriteJujuStatusStep
-from sunbeam.jobs.checks import DaemonGroupCheck
 from sunbeam.jobs.common import (
     run_plan,
     run_preflight_checks,
 )
 from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.juju import JujuHelper
+
+from anvil.jobs.checks import DaemonGroupCheck
 
 LOG = logging.getLogger(__name__)
 console = Console()

--- a/anvil-python/anvil/commands/manifest.py
+++ b/anvil-python/anvil/commands/manifest.py
@@ -25,12 +25,12 @@ from sunbeam.clusterd.service import (
     ClusterServiceUnavailableException,
     ManifestItemNotFoundException,
 )
-from sunbeam.jobs.checks import DaemonGroupCheck, VerifyBootstrappedCheck
 from sunbeam.jobs.common import FORMAT_TABLE, FORMAT_YAML, run_preflight_checks
 from sunbeam.jobs.deployment import Deployment
 from sunbeam.utils import asdict_with_extra_fields
 import yaml
 
+from anvil.jobs.checks import DaemonGroupCheck, VerifyBootstrappedCheck
 from anvil.jobs.manifest import Manifest
 
 LOG = logging.getLogger(__name__)

--- a/anvil-python/anvil/jobs/checks.py
+++ b/anvil-python/anvil/jobs/checks.py
@@ -14,8 +14,13 @@
 # limitations under the License.
 
 import logging
+import os
 
-from sunbeam.jobs.checks import Check
+from sunbeam.jobs.checks import (
+    DaemonGroupCheck as SunbeamDaemonGroupCheck,
+    SystemRequirementsCheck as SunbeamSystemRequirementsCheck,
+    VerifyBootstrappedCheck as SunbeamVerifyBootstrappedCheck,
+)
 from sunbeam.jobs.common import (
     get_host_total_cores,
     get_host_total_ram,
@@ -26,14 +31,8 @@ from anvil.jobs.common import RAM_4_GB_IN_KB
 LOG = logging.getLogger(__name__)
 
 
-class SystemRequirementsCheck(Check):
+class SystemRequirementsCheck(SunbeamSystemRequirementsCheck):
     """Check if machine has minimum 4 cores and 16GB RAM."""
-
-    def __init__(self) -> None:
-        super().__init__(
-            "Check for system requirements",
-            "Checking for host configuration of minimum 4 core and 16G RAM",
-        )
 
     def run(self) -> bool:
         host_total_ram = get_host_total_ram()
@@ -43,3 +42,23 @@ class SystemRequirementsCheck(Check):
             LOG.warning(self.message)
 
         return True
+
+
+class DaemonGroupCheck(SunbeamDaemonGroupCheck):
+    """Check if user is member of socket group."""
+
+    def run(self) -> bool:
+        ret: bool = super().run()
+        if not ret:
+            self.message: str = self.message.replace("sunbeam", "anvil")
+        return ret
+
+
+class VerifyBootstrappedCheck(SunbeamVerifyBootstrappedCheck):
+    """Check deployment has been bootstrapped."""
+
+    def run(self) -> bool:
+        ret: bool = super().run()
+        if not ret:
+            self.message: str = self.message.replace("sunbeam", "anvil")
+        return ret

--- a/anvil-python/anvil/main.py
+++ b/anvil-python/anvil/main.py
@@ -55,7 +55,7 @@ def manifest(ctx: click.Context) -> None:
 
 def main() -> None:
     snap = Snap()
-    logfile = log.prepare_logfile(snap.paths.user_common / "logs", "sunbeam")
+    logfile = log.prepare_logfile(snap.paths.user_common / "logs", "anvil")
     log.setup_root_logging(logfile)
     cli.add_command(prepare_node_cmds.prepare_node_script)
     cli.add_command(inspect_cmds.inspect)

--- a/anvil-python/anvil/provider/local/commands.py
+++ b/anvil-python/anvil/provider/local/commands.py
@@ -24,7 +24,6 @@ from snaphelpers import Snap
 from sunbeam import utils
 
 # from sunbeam.commands import refresh as refresh_cmds
-from sunbeam.commands import resize as resize_cmds
 from sunbeam.commands.clusterd import (
     ClusterAddJujuUserStep,
     ClusterAddNodeStep,
@@ -48,7 +47,6 @@ from sunbeam.commands.juju import (
 )
 from sunbeam.commands.terraform import TerraformInitStep
 from sunbeam.jobs.checks import (
-    DaemonGroupCheck,
     JujuSnapCheck,
     LocalShareCheck,
     SshKeysConnectedCheck,
@@ -93,7 +91,7 @@ from anvil.commands.postgresql import (
     DeployPostgreSQLApplicationStep,
     RemovePostgreSQLUnitStep,
 )
-from anvil.jobs.checks import SystemRequirementsCheck
+from anvil.jobs.checks import DaemonGroupCheck, SystemRequirementsCheck
 from anvil.jobs.common import (
     Role,
     roles_to_str_list,
@@ -140,7 +138,6 @@ class LocalProvider(ProviderBase):
         cluster.add_command(join)
         cluster.add_command(list)
         cluster.add_command(remove)
-        cluster.add_command(resize_cmds.resize)
         # cluster.add_command(refresh_cmds.refresh)
 
     def deployment_type(self) -> tuple[str, type[Deployment]]:


### PR DESCRIPTION
This PR includes the following:

- removal of `cluster resize` command which does not apply to `maas-anvil`
- update on checks' messages to mention `maas-anvil` instead of `sunbeam`

**NOTE:** The microcluster that maas-anvil is using is the sunbeam microcluster. The references to it as `sunbeam` will remain since otherwise a huge refactor of common functions between sunbeam and anvil is required. There is not a huge benefit to do so. In addition, the sunbeam microcluster is used as a whole, without any modification.