### PR TITLE
fix: allow node roles different than bootstrapped node

### DIFF
--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -13,8 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
+
 from sunbeam.clusterd.client import Client
+from sunbeam.commands.terraform import TerraformInitStep
 from sunbeam.jobs.juju import JujuHelper
+from sunbeam.jobs.manifest import BaseStep
 from sunbeam.jobs.steps import (
     AddMachineUnitsStep,
     DeployMachineApplicationStep,
@@ -22,6 +26,7 @@ from sunbeam.jobs.steps import (
 )
 
 from anvil.jobs.manifest import Manifest
+from anvil.provider.local.deployment import LocalDeployment
 
 APPLICATION = "haproxy"
 CONFIG_KEY = "TerraformVarsHaproxyPlan"
@@ -103,3 +108,21 @@ class RemoveHAProxyUnitStep(RemoveMachineUnitStep):
 
     def get_unit_timeout(self) -> int:
         return HAPROXY_UNIT_TIMEOUT
+
+
+def haproxy_install_steps(
+    client: Client,
+    manifest: Manifest,
+    jhelper: JujuHelper,
+    deployment: LocalDeployment,
+    fqdn: str,
+) -> List[BaseStep]:
+    return [
+        TerraformInitStep(manifest.get_tfhelper("haproxy-plan")),
+        DeployHAProxyApplicationStep(
+            client, manifest, jhelper, deployment.infrastructure_model
+        ),
+        AddHAProxyUnitsStep(
+            client, fqdn, jhelper, deployment.infrastructure_model
+        ),
+    ]

--- a/anvil-python/anvil/commands/maas_region.py
+++ b/anvil-python/anvil/commands/maas_region.py
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
+from typing import Any, List
 
 from sunbeam.clusterd.client import Client
+from sunbeam.commands.terraform import TerraformInitStep
 from sunbeam.jobs.juju import JujuHelper
+from sunbeam.jobs.manifest import BaseStep
 from sunbeam.jobs.steps import (
     AddMachineUnitsStep,
     DeployMachineApplicationStep,
@@ -24,6 +26,7 @@ from sunbeam.jobs.steps import (
 )
 
 from anvil.jobs.manifest import Manifest
+from anvil.provider.local.deployment import LocalDeployment
 
 APPLICATION = "maas-region"
 CONFIG_KEY = "TerraformVarsMaasregionPlan"
@@ -115,3 +118,21 @@ class RemoveMAASRegionUnitStep(RemoveMachineUnitStep):
 
     def get_unit_timeout(self) -> int:
         return MAASREGION_UNIT_TIMEOUT
+
+
+def maas_region_install_steps(
+    client: Client,
+    manifest: Manifest,
+    jhelper: JujuHelper,
+    deployment: LocalDeployment,
+    fqdn: str,
+) -> List[BaseStep]:
+    return [
+        TerraformInitStep(manifest.get_tfhelper("maas-region-plan")),
+        DeployMAASRegionApplicationStep(
+            client, manifest, jhelper, deployment.infrastructure_model
+        ),
+        AddMAASRegionUnitsStep(
+            client, fqdn, jhelper, deployment.infrastructure_model
+        ),
+    ]

--- a/anvil-python/anvil/commands/postgresql.py
+++ b/anvil-python/anvil/commands/postgresql.py
@@ -13,8 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
+
 from sunbeam.clusterd.client import Client
+from sunbeam.commands.terraform import TerraformInitStep
 from sunbeam.jobs.juju import JujuHelper
+from sunbeam.jobs.manifest import BaseStep
 from sunbeam.jobs.steps import (
     AddMachineUnitsStep,
     DeployMachineApplicationStep,
@@ -22,6 +26,7 @@ from sunbeam.jobs.steps import (
 )
 
 from anvil.jobs.manifest import Manifest
+from anvil.provider.local.deployment import LocalDeployment
 
 APPLICATION = "postgresql"
 CONFIG_KEY = "TerraformVarsPostgresqlPlan"
@@ -105,3 +110,21 @@ class RemovePostgreSQLUnitStep(RemoveMachineUnitStep):
 
     def get_unit_timeout(self) -> int:
         return POSTGRESQL_UNIT_TIMEOUT
+
+
+def postgresql_install_steps(
+    client: Client,
+    manifest: Manifest,
+    jhelper: JujuHelper,
+    deployment: LocalDeployment,
+    fqdn: str,
+) -> List[BaseStep]:
+    return [
+        TerraformInitStep(manifest.get_tfhelper("postgresql-plan")),
+        DeployPostgreSQLApplicationStep(
+            client, manifest, jhelper, deployment.infrastructure_model
+        ),
+        AddPostgreSQLUnitsStep(
+            client, fqdn, jhelper, deployment.infrastructure_model
+        ),
+    ]


### PR DESCRIPTION
This PR includes the following:

- a fix for new nodes that are joining the anvil cluster. Instead of running only the add unit steps of each role, anvil has to also run the terraform init and install application steps. Otherwise, if a new node wants to join with a role that bootstrap node does not have, the usage of only the add unit step fails. At this point, the terraform plan of the role has not been initialized yet and the charmed application has not been installed
- an overall refactor of bootstrap and join commands to make them more comprehensible