### PR TITLE
Connect maas-anvil to dot-config-anvil slot during prepare_node script

### DIFF
--- a/anvil-python/anvil/commands/prepare_node.py
+++ b/anvil-python/anvil/commands/prepare_node.py
@@ -79,6 +79,7 @@ mkdir -p $HOME/.config/anvil
 # Juju model.
 sudo snap connect maas-anvil:juju-bin juju:juju-bin
 sudo snap connect maas-anvil:dot-local-share-juju
+sudo snap connect maas-anvil:dot-config-anvil
 """
 
 


### PR DESCRIPTION
MAAS Anvil cannot access `$HOME/.config/anvil` with the current `prepare_node` script. This PR provides such access.