### PR TITLE
bug: configure maximum db connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ ubuntu@infra1:~$ maas-anvil cluster bootstrap \
 Note: You will be asked for a `virtual_ip` during installation of the HAProxy charm, if `accept-defaults` is omitted.
 Pass an empty value to disable it, or any valid IP to enable; the Keepalived charm will be installed to enable connecting to HA MAAS using the VIP.
 
+#### PostgreSQL max_connections
+
+You will be asked for a `max_connections` during installation of the PostgreSQL charm, if `accept-defaults` is omitted. Use `default` if you need the default values of PostgreSQL to be applied to [max_connections](https://www.postgresql.org/docs/14/runtime-config-connection.html). If you are aiming for MAAS HA though you have to do one of the following:
+
+- If number of MAAS region nodes is known beforehand, you can calculate the desired max_connections and set them, based on the formula: `max_connections = max(100, 10 + 50 * number_of_region_nodes)`.
+- If number of MAAS region nodes is not known, you can set `max_connections` to `dynamic` and let MAAS Anvil recalculate the appropriate PostgreSQL `max_connections` every time a region node is joining or leaving the Anvil cluster. **This options includes a database restart with every modification.**
+
 ### Add new nodes to the MAAS cluster
 
 ```bash

--- a/anvil-python/anvil/commands/maas_agent.py
+++ b/anvil-python/anvil/commands/maas_agent.py
@@ -17,8 +17,8 @@ from typing import List
 
 from sunbeam.clusterd.client import Client
 from sunbeam.commands.terraform import TerraformInitStep
+from sunbeam.jobs.common import BaseStep
 from sunbeam.jobs.juju import JujuHelper
-from sunbeam.jobs.manifest import BaseStep
 from sunbeam.jobs.steps import (
     AddMachineUnitsStep,
     DeployMachineApplicationStep,
@@ -26,7 +26,6 @@ from sunbeam.jobs.steps import (
 )
 
 from anvil.jobs.manifest import Manifest
-from anvil.provider.local.deployment import LocalDeployment
 
 APPLICATION = "maas-agent"
 CONFIG_KEY = "TerraformVarsMaasagentPlan"
@@ -116,15 +115,11 @@ def maas_agent_install_steps(
     client: Client,
     manifest: Manifest,
     jhelper: JujuHelper,
-    deployment: LocalDeployment,
+    model: str,
     fqdn: str,
 ) -> List[BaseStep]:
     return [
         TerraformInitStep(manifest.get_tfhelper("maas-agent-plan")),
-        DeployMAASAgentApplicationStep(
-            client, manifest, jhelper, deployment.infrastructure_model
-        ),
-        AddMAASAgentUnitsStep(
-            client, fqdn, jhelper, deployment.infrastructure_model
-        ),
+        DeployMAASAgentApplicationStep(client, manifest, jhelper, model),
+        AddMAASAgentUnitsStep(client, fqdn, jhelper, model),
     ]

--- a/anvil-python/anvil/commands/maas_region.py
+++ b/anvil-python/anvil/commands/maas_region.py
@@ -17,8 +17,8 @@ from typing import Any, List
 
 from sunbeam.clusterd.client import Client
 from sunbeam.commands.terraform import TerraformInitStep
+from sunbeam.jobs.common import BaseStep
 from sunbeam.jobs.juju import JujuHelper
-from sunbeam.jobs.manifest import BaseStep
 from sunbeam.jobs.steps import (
     AddMachineUnitsStep,
     DeployMachineApplicationStep,
@@ -26,7 +26,6 @@ from sunbeam.jobs.steps import (
 )
 
 from anvil.jobs.manifest import Manifest
-from anvil.provider.local.deployment import LocalDeployment
 
 APPLICATION = "maas-region"
 CONFIG_KEY = "TerraformVarsMaasregionPlan"
@@ -124,15 +123,11 @@ def maas_region_install_steps(
     client: Client,
     manifest: Manifest,
     jhelper: JujuHelper,
-    deployment: LocalDeployment,
+    model: str,
     fqdn: str,
 ) -> List[BaseStep]:
     return [
         TerraformInitStep(manifest.get_tfhelper("maas-region-plan")),
-        DeployMAASRegionApplicationStep(
-            client, manifest, jhelper, deployment.infrastructure_model
-        ),
-        AddMAASRegionUnitsStep(
-            client, fqdn, jhelper, deployment.infrastructure_model
-        ),
+        DeployMAASRegionApplicationStep(client, manifest, jhelper, model),
+        AddMAASRegionUnitsStep(client, fqdn, jhelper, model),
     ]

--- a/anvil-python/anvil/provider/local/deployment.py
+++ b/anvil-python/anvil/provider/local/deployment.py
@@ -27,6 +27,10 @@ from sunbeam.provider.local.deployment import (
 )
 
 from anvil.commands.haproxy import KEEPALIVED_CONFIG_KEY, keepalived_questions
+from anvil.commands.postgresql import (
+    POSTGRESQL_CONFIG_KEY,
+    postgresql_questions,
+)
 
 LOG = logging.getLogger(__name__)
 LOCAL_TYPE = "local"
@@ -51,6 +55,20 @@ class LocalDeployment(SunbeamLocalDeployment):
         )
         preseed_content.extend(
             show_questions(bootstrap_bank, section="bootstrap")
+        )
+
+        # PostgreSQL questions
+        try:
+            variables = load_answers(client, POSTGRESQL_CONFIG_KEY)
+        except ClusterServiceUnavailableException:
+            variables = {}
+        postgresql_config_bank = QuestionBank(
+            questions=postgresql_questions(),
+            console=console,
+            previous_answers=variables,
+        )
+        preseed_content.extend(
+            show_questions(postgresql_config_bank, section="postgres")
         )
 
         # HAProxy questions

--- a/anvil-python/anvil/versions.py
+++ b/anvil-python/anvil/versions.py
@@ -16,7 +16,7 @@
 MAAS_REGION_CHANNEL = "latest/edge"
 MAAS_AGENT_CHANNEL = "latest/edge"
 POSTGRESQL_CHANNEL = "14/candidate"
-PGBOUNCER_CHANNEL = "1/candidate"
+PGBOUNCER_CHANNEL = "1/beta"
 HAPROXY_CHANNEL = "latest/stable"
 KEEPALIVED_CHANNEL = "latest/stable"
 

--- a/cloud/etc/deploy-maas-region/main.tf
+++ b/cloud/etc/deploy-maas-region/main.tf
@@ -58,8 +58,8 @@ resource "juju_application" "pgbouncer" {
   }
 
   config = merge({
-    pool_mode          = "transaction"
-    max_db_connections = floor(90 / max(length(var.machine_ids), 1))
+    pool_mode          = "session"
+    max_db_connections = var.max_connections_per_region
   }, var.charm_pgbouncer_config)
 }
 

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -51,7 +51,7 @@ variable "enable_haproxy" {
 variable "charm_pgbouncer_channel" {
   description = "Operator channel for PgBouncer deployment"
   type        = string
-  default     = "1/candidate"
+  default     = "1/beta"
 }
 
 variable "charm_pgbouncer_revision" {
@@ -64,4 +64,10 @@ variable "charm_pgbouncer_config" {
   description = "Operator config for PgBouncer deployment"
   type        = map(string)
   default     = {}
+}
+
+variable "max_connections_per_region" {
+  description = "Maximum number of concurrent connections to allow to the database server per region"
+  type        = number
+  default     = 50
 }

--- a/cloud/etc/deploy-postgresql/main.tf
+++ b/cloud/etc/deploy-postgresql/main.tf
@@ -30,6 +30,16 @@ data "juju_model" "machine_model" {
   name = var.machine_model
 }
 
+locals {
+  max_connections = var.max_connections == "default" ? {} : (
+    var.max_connections == "dynamic" ? {
+      experimental_max_connections = max(100, 10 + var.max_connections_per_region * var.maas_region_nodes)
+      } : {
+      experimental_max_connections = tonumber(var.max_connections)
+    }
+  )
+}
+
 resource "juju_application" "postgresql" {
   name  = "postgresql"
   model = data.juju_model.machine_model.name
@@ -42,5 +52,5 @@ resource "juju_application" "postgresql" {
     base     = "ubuntu@22.04"
   }
 
-  config = var.charm_postgresql_config
+  config = merge(local.max_connections, var.charm_postgresql_config)
 }

--- a/cloud/etc/deploy-postgresql/variables.tf
+++ b/cloud/etc/deploy-postgresql/variables.tf
@@ -41,3 +41,21 @@ variable "machine_model" {
   description = "Model to deploy to"
   type        = string
 }
+
+variable "max_connections" {
+  description = "Maximum number of concurrent connections to allow to the database server"
+  type        = string
+  default     = "default"
+}
+
+variable "maas_region_nodes" {
+  description = "Total number of MAAS region nodes"
+  type        = number
+  default     = 0
+}
+
+variable "max_connections_per_region" {
+  description = "Maximum number of concurrent connections to allow to the database server per region"
+  type        = number
+  default     = 50
+}


### PR DESCRIPTION
The PR includes the following changes:

- Set PgBouncer `pool_mode` to `session` since `pg_advisory_lock` cannot be supported by `transaction` mode
- Set a predefined number for the maximum connections to the database server from each PgBouncer unit to be 50. Those are the maximum connections that MAAS up to 3.4 requires per region controller (40), plus a buffer of 10. PgBouncer units are subordinate units of `maas-region` units, so it has to be a 1-1 mapping. The extra 10, if not used they will be closed by PgBouncer.
- Provide a mechanism to configure `experimental_max_connections` to PostgreSQL charm with three options:
  - `default`: It does not set `experimental_max_connections` at all. It will use the system defaults of PostgreSQL
  - `dynamic`: It configures `experimental_max_connections` based on the number of maas-region units. If chosen, it will use the maximum of 100 (default max connections) and 50 * `number_of_region_units` + 10 (required by PgBouncer). This option also includes a restart of the PostgreSQL server units, so it is up to the practitioner to use it.
  - exact number of connections (`100<=n<=500`): It statically configures the `experimental_max_connections` of the PostgreSQL server. If specified during bootstrap (e.g., the MAAS cluster topology is predefined and total number of regions is known), it will be set from the beginning.
- A `ReapplyPostgreSQLTerraformPlanStep` that will re-configure the `experimental_max_connections` when new `region` nodes are joining/leaving the cluster and max_connections mechanism is set to `dynamic`
- A small refactor on the functions that fetch all the Steps of a given role

Fixes: #11 