### PR TITLE
feat: Add node's ssh key to Juju model on join

### DIFF
--- a/anvil-python/anvil/commands/juju.py
+++ b/anvil-python/anvil/commands/juju.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from os import environ
+import os.path
+import subprocess
+
+from rich.status import Status
+from sunbeam.jobs.common import BaseStep, Result, ResultType
+
+
+class JujuAddSSHKeyStep(BaseStep):
+    """Add this node's SSH key to the Juju model"""
+
+    def __init__(self) -> None:
+        super().__init__("Add SSH key", "Adding SSH key to Juju model")
+
+    def run(self, status: Status | None) -> Result:
+        try:
+            with open(
+                os.path.join(
+                    f"{environ['SNAP_REAL_HOME']}", ".ssh/id_rsa.pub"
+                ),
+            ) as f:
+                key = f.read().removesuffix(
+                    "\n"
+                )  # juju does not like this newline
+                cmd = ["juju", "add-ssh-key", key]
+                result = subprocess.run(
+                    cmd,
+                    check=True,
+                    capture_output=True,
+                )
+        except subprocess.CalledProcessError:
+            return Result(
+                ResultType.FAILED,
+                message=f"juju add-ssh-key failed: {result.stderr.decode('utf-8', errors='ignore')}",
+            )
+        except FileNotFoundError:
+            return Result(
+                ResultType.FAILED,
+                message="Could not find public ssh key (~/.ssh/id_rsa.pub)",
+            )
+        return Result(ResultType.COMPLETED)

--- a/anvil-python/anvil/jobs/checks.py
+++ b/anvil-python/anvil/jobs/checks.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import logging
-import os
 
 from sunbeam.jobs.checks import (
     DaemonGroupCheck as SunbeamDaemonGroupCheck,

--- a/anvil-python/anvil/provider/local/commands.py
+++ b/anvil-python/anvil/provider/local/commands.py
@@ -74,6 +74,7 @@ from anvil.commands.haproxy import (
     RemoveHAProxyUnitStep,
     haproxy_install_steps,
 )
+from anvil.commands.juju import JujuAddSSHKeyStep
 from anvil.commands.maas_agent import (
     RemoveMAASAgentUnitStep,
     maas_agent_install_steps,
@@ -429,6 +430,7 @@ def join(
         SaveJujuUserLocallyStep(name, data_location),
         RegisterJujuUserStep(client, name, controller, data_location),
         AddJujuMachineStep(ip),
+        JujuAddSSHKeyStep(),
     ]
     plan1_results = run_plan(plan1, console)
 


### PR DESCRIPTION
Uses `juju add-ssh-key` to add the node's public key to the model, allowing users to ssh to each machine with `juju ssh`