### PR TITLE
chore(deps): switch to stable channels for PostgreSQL/PgBouncer

### DIFF
--- a/anvil-python/anvil/versions.py
+++ b/anvil-python/anvil/versions.py
@@ -15,8 +15,8 @@
 
 MAAS_REGION_CHANNEL = "latest/edge"
 MAAS_AGENT_CHANNEL = "latest/edge"
-POSTGRESQL_CHANNEL = "14/candidate"
-PGBOUNCER_CHANNEL = "1/beta"
+POSTGRESQL_CHANNEL = "14/stable"
+PGBOUNCER_CHANNEL = "1/stable"
 HAPROXY_CHANNEL = "latest/stable"
 KEEPALIVED_CHANNEL = "latest/stable"
 

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -51,7 +51,7 @@ variable "enable_haproxy" {
 variable "charm_pgbouncer_channel" {
   description = "Operator channel for PgBouncer deployment"
   type        = string
-  default     = "1/beta"
+  default     = "1/stable"
 }
 
 variable "charm_pgbouncer_revision" {


### PR DESCRIPTION
- Switches the default channel of Postgresql to 14/stable: rev. 429 is now on 14/stable
- Switches the default channel of Pgbouncer to 1/stable: rev. 278 is now on 1/stable

Resolved GH: https://github.com/canonical/maas-anvil/issues/41