### PR TITLE
refactor: Remove `sunbeam` from error message in juju-login

### DIFF
--- a/anvil-python/anvil/commands/utils.py
+++ b/anvil-python/anvil/commands/utils.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import click
+from rich.console import Console
+from sunbeam.commands.juju import JujuLoginStep
+from sunbeam.jobs.common import run_plan, run_preflight_checks
+
+from anvil.jobs.checks import VerifyBootstrappedCheck
+from anvil.provider.local.deployment import LocalDeployment
+
+LOG = logging.getLogger(__name__)
+console = Console()
+
+
+@click.command()
+@click.pass_context
+def juju_login(ctx: click.Context) -> None:
+    """Login to the controller with current host user."""
+    deployment: LocalDeployment = ctx.obj
+    client = deployment.get_client()
+    preflight_checks = [VerifyBootstrappedCheck(client)]
+    run_preflight_checks(preflight_checks, console)
+
+    plan = []
+    plan.append(JujuLoginStep(deployment.juju_account))
+
+    run_plan(plan, console)
+
+    console.print("Juju re-login complete.")

--- a/anvil-python/anvil/commands/utils.py
+++ b/anvil-python/anvil/commands/utils.py
@@ -32,13 +32,9 @@ console = Console()
 def juju_login(ctx: click.Context) -> None:
     """Login to the controller with current host user."""
     deployment: LocalDeployment = ctx.obj
-    client = deployment.get_client()
-    preflight_checks = [VerifyBootstrappedCheck(client)]
-    run_preflight_checks(preflight_checks, console)
-
-    plan = []
-    plan.append(JujuLoginStep(deployment.juju_account))
-
-    run_plan(plan, console)
+    run_preflight_checks(
+        [VerifyBootstrappedCheck(deployment.get_client())], console
+    )
+    run_plan([JujuLoginStep(deployment.juju_account)], console)
 
     console.print("Juju re-login complete.")

--- a/anvil-python/anvil/main.py
+++ b/anvil-python/anvil/main.py
@@ -19,7 +19,6 @@ from sunbeam import log
 from sunbeam.commands import (
     configure as configure_cmds,
 )
-from sunbeam.commands.utils import juju_login
 
 from anvil.commands import (
     inspect as inspect_cmds,
@@ -27,6 +26,7 @@ from anvil.commands import (
     prepare_node as prepare_node_cmds,
     refresh as refresh_cmds,
 )
+from anvil.commands.utils import juju_login
 from anvil.provider.local.commands import LocalProvider
 from anvil.provider.local.deployment import LocalDeployment
 from anvil.utils import CatchGroup


### PR DESCRIPTION
Using `sunbeam.commands.utils.juju_login` worked well, except on a failure would output the message:
> Error: Deployment not bootstrapped or bootstrap process has not completed succesfully. Please run `sunbeam cluster bootstrap`

This implements the same functionality except using the anvil `VerifyBootstrappedCheck` which includes sanitation of `sunbeam` in error messages.