### PR TITLE
refactor: remove sunbeam from console

### DIFF
--- a/anvil-python/anvil/commands/clusterd.py
+++ b/anvil-python/anvil/commands/clusterd.py
@@ -45,7 +45,7 @@ class ClusterJoinNodeStep(SunbeamClusterJoinNodeStep):
         super().__init__(client=client, token=token, role=role)
 
         self.name = "Join node to Cluster"
-        self.description = "Adding node to anvil cluster"
+        self.description = "Adding node to Anvil cluster"
 
 
 class ClusterListNodeStep(SunbeamClusterListNodeStep):

--- a/anvil-python/anvil/commands/clusterd.py
+++ b/anvil-python/anvil/commands/clusterd.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import List
+
+from sunbeam.clusterd.client import Client
+
+LOG = logging.getLogger(__name__)
+
+from sunbeam.commands.clusterd import (
+    ClusterInitStep as SunbeamClusterInitStep,
+    ClusterJoinNodeStep as SunbeamClusterJoinNodeStep,
+    ClusterListNodeStep as SunbeamClusterListNodeStep,
+    ClusterRemoveNodeStep as SunbeamClusterRemoveNodeStep,
+)
+
+
+class ClusterInitStep(SunbeamClusterInitStep):
+    """Bootstrap clustering on anvil clusterd."""
+
+    def __init__(self, client: Client, role: List[str], machineid: int):
+        super().__init__(client=client, role=role, machineid=machineid)
+
+        self.name = "Bootstrap Cluster"
+        self.description = "Bootstrapping Anvil cluster"
+
+
+class ClusterJoinNodeStep(SunbeamClusterJoinNodeStep):
+    """Join node to the anvil cluster."""
+
+    def __init__(self, client: Client, token: str, role: List[str]):
+        super().__init__(client=client, token=token, role=role)
+
+        self.name = "Join node to Cluster"
+        self.description = "Adding node to anvil cluster"
+
+
+class ClusterListNodeStep(SunbeamClusterListNodeStep):
+    """List nodes in the anvil cluster."""
+
+    def __init__(self, client: Client):
+        super().__init__(client=client)
+
+        self.name = "List nodes of Cluster"
+        self.description = "Listing nodes in anvil cluster"
+
+
+class ClusterRemoveNodeStep(SunbeamClusterRemoveNodeStep):
+    """Remove node from the anvil cluster."""
+
+    def __init__(self, client: Client, name: str):
+        super().__init__(client=client, name=name)
+
+        self.name = "Remove node from Cluster"
+        self.description = "Removing node from anvil cluster"

--- a/anvil-python/anvil/commands/clusterd.py
+++ b/anvil-python/anvil/commands/clusterd.py
@@ -29,7 +29,7 @@ from sunbeam.commands.clusterd import (
 
 
 class ClusterInitStep(SunbeamClusterInitStep):
-    """Bootstrap clustering on anvil clusterd."""
+    """Bootstrap clustering on Anvil clusterd."""
 
     def __init__(self, client: Client, role: List[str], machineid: int):
         super().__init__(client=client, role=role, machineid=machineid)
@@ -39,7 +39,7 @@ class ClusterInitStep(SunbeamClusterInitStep):
 
 
 class ClusterJoinNodeStep(SunbeamClusterJoinNodeStep):
-    """Join node to the anvil cluster."""
+    """Join node to the Anvil cluster."""
 
     def __init__(self, client: Client, token: str, role: List[str]):
         super().__init__(client=client, token=token, role=role)
@@ -49,20 +49,20 @@ class ClusterJoinNodeStep(SunbeamClusterJoinNodeStep):
 
 
 class ClusterListNodeStep(SunbeamClusterListNodeStep):
-    """List nodes in the anvil cluster."""
+    """List nodes in the Anvil cluster."""
 
     def __init__(self, client: Client):
         super().__init__(client=client)
 
         self.name = "List nodes of Cluster"
-        self.description = "Listing nodes in anvil cluster"
+        self.description = "Listing nodes in Anvil cluster"
 
 
 class ClusterRemoveNodeStep(SunbeamClusterRemoveNodeStep):
-    """Remove node from the anvil cluster."""
+    """Remove node from the Anvil cluster."""
 
     def __init__(self, client: Client, name: str):
         super().__init__(client=client, name=name)
 
         self.name = "Remove node from Cluster"
-        self.description = "Removing node from anvil cluster"
+        self.description = "Removing node from Anvil cluster"

--- a/anvil-python/anvil/provider/local/commands.py
+++ b/anvil-python/anvil/provider/local/commands.py
@@ -63,7 +63,6 @@ from sunbeam.provider.base import ProviderBase
 from sunbeam.provider.local.deployment import LOCAL_TYPE
 import yaml
 
-# from sunbeam.commands import refresh as refresh_cmds
 from anvil.commands.clusterd import (
     ClusterInitStep,
     ClusterJoinNodeStep,

--- a/anvil-python/anvil/provider/local/commands.py
+++ b/anvil-python/anvil/provider/local/commands.py
@@ -22,15 +22,9 @@ from rich.console import Console
 from rich.table import Table
 from snaphelpers import Snap
 from sunbeam import utils
-
-# from sunbeam.commands import refresh as refresh_cmds
 from sunbeam.commands.clusterd import (
     ClusterAddJujuUserStep,
     ClusterAddNodeStep,
-    ClusterInitStep,
-    ClusterJoinNodeStep,
-    ClusterListNodeStep,
-    ClusterRemoveNodeStep,
     ClusterUpdateJujuControllerStep,
     ClusterUpdateNodeStep,
 )
@@ -69,6 +63,13 @@ from sunbeam.provider.base import ProviderBase
 from sunbeam.provider.local.deployment import LOCAL_TYPE
 import yaml
 
+# from sunbeam.commands import refresh as refresh_cmds
+from anvil.commands.clusterd import (
+    ClusterInitStep,
+    ClusterJoinNodeStep,
+    ClusterListNodeStep,
+    ClusterRemoveNodeStep,
+)
 from anvil.commands.haproxy import (
     RemoveHAProxyUnitStep,
     haproxy_install_steps,


### PR DESCRIPTION
- add an intermediate class for cluster operations that replaces "sunbeam" in console logs with "anvil"