### PR TITLE
fix: manifest with empty default values

### DIFF
--- a/anvil-python/anvil/jobs/questions.py
+++ b/anvil-python/anvil/jobs/questions.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from sunbeam.jobs.questions import QuestionBank
+
+
+def show_questions(
+    question_bank: QuestionBank,
+    section: str | None = None,
+    subsection: str | None = None,
+    section_description: str | None = None,
+    comment_out: bool = False,
+) -> list[str]:
+    """Return preseed questions as list."""
+    lines = []
+    space = " "
+    indent = ""
+    outer_indent = space * 2
+    if comment_out:
+        comment = "# "
+    else:
+        comment = ""
+    if section:
+        if section_description:
+            lines.append(
+                f"{outer_indent}{comment}{indent}# {section_description}"
+            )
+        lines.append(f"{outer_indent}{comment}{indent}{section}:")
+        indent = space * 2
+    if subsection:
+        lines.append(f"{outer_indent}{comment}{indent}{subsection}:")
+        indent = space * 4
+    for key, question in question_bank.questions.items():
+        default = question.calculate_default() or ""
+        lines.append(f"{outer_indent}{comment}{indent}# {question.question}")
+        lines.append(f'{outer_indent}{comment}{indent}{key}: "{default}"')
+
+    return lines

--- a/anvil-python/anvil/provider/local/deployment.py
+++ b/anvil-python/anvil/provider/local/deployment.py
@@ -21,7 +21,7 @@ from sunbeam.clusterd.service import (
     ClusterServiceUnavailableException,
 )
 from sunbeam.commands.juju import BOOTSTRAP_CONFIG_KEY, bootstrap_questions
-from sunbeam.jobs.questions import QuestionBank, load_answers, show_questions
+from sunbeam.jobs.questions import QuestionBank, load_answers
 from sunbeam.provider.local.deployment import (
     LocalDeployment as SunbeamLocalDeployment,
 )
@@ -31,6 +31,7 @@ from anvil.commands.postgresql import (
     POSTGRESQL_CONFIG_KEY,
     postgresql_questions,
 )
+from anvil.jobs.questions import show_questions
 
 LOG = logging.getLogger(__name__)
 LOCAL_TYPE = "local"
@@ -76,13 +77,13 @@ class LocalDeployment(SunbeamLocalDeployment):
             variables = load_answers(client, HAPROXY_CONFIG_KEY)
         except ClusterServiceUnavailableException:
             variables = {}
-        keepalived_config_bank = QuestionBank(
+        haproxy_config_bank = QuestionBank(
             questions=haproxy_questions(),
             console=console,
             previous_answers=variables,
         )
         preseed_content.extend(
-            show_questions(keepalived_config_bank, section="haproxy")
+            show_questions(haproxy_config_bank, section="haproxy")
         )
 
         preseed_content_final = "\n".join(preseed_content)


### PR DESCRIPTION
- Add an string as the default value instead of empty YAML value, when default value is the empty string
- Modify haproxy SSL questions to default to empty string
- Update question bank variable name from keepalived to haproxy when generating a manifest
- Modify vip question validator to retun None or raise ValueError

resolves: #58 