### PR TITLE
refactor: fix known issues in refresh command

### DIFF
--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -150,6 +150,7 @@ class DeployHAProxyApplicationStep(DeployMachineApplicationStep):
         deployment_preseed: dict[Any, Any] | None = None,
         accept_defaults: bool = False,
         refresh: bool = False,
+        verb: str = "Deploy",
     ):
         super().__init__(
             client,
@@ -159,8 +160,8 @@ class DeployHAProxyApplicationStep(DeployMachineApplicationStep):
             APPLICATION,
             model,
             "haproxy-plan",
-            "Deploy HAProxy",
-            "Deploying HAProxy",
+            f"{verb.capitalize()} HAProxy",
+            f"{verb.capitalize()}ing HAProxy",
             refresh,
         )
         self.preseed = deployment_preseed or {}
@@ -376,5 +377,6 @@ def haproxy_upgrade_steps(
             model,
             deployment_preseed=preseed,
             refresh=True,
+            verb="Refresh",
         ),
     ]

--- a/anvil-python/anvil/commands/maas_agent.py
+++ b/anvil-python/anvil/commands/maas_agent.py
@@ -47,6 +47,7 @@ class DeployMAASAgentApplicationStep(DeployMachineApplicationStep):
         jhelper: JujuHelper,
         model: str,
         refresh: bool = False,
+        verb: str = "Deploy",
     ):
         super().__init__(
             client,
@@ -56,8 +57,8 @@ class DeployMAASAgentApplicationStep(DeployMachineApplicationStep):
             APPLICATION,
             model,
             "maas-agent-plan",
-            "Deploy MAAS Agent",
-            "Deploying MAAS Agent",
+            f"{verb.capitalize()} MAAS Agent",
+            f"{verb.capitalize()}ing MAAS Agent",
             refresh,
         )
 
@@ -134,6 +135,6 @@ def maas_agent_upgrade_steps(
     return [
         TerraformInitStep(manifest.get_tfhelper("maas-agent-plan")),
         DeployMAASAgentApplicationStep(
-            client, manifest, jhelper, model, refresh=True
+            client, manifest, jhelper, model, refresh=True, verb="Refresh"
         ),
     ]

--- a/anvil-python/anvil/commands/maas_region.py
+++ b/anvil-python/anvil/commands/maas_region.py
@@ -71,7 +71,7 @@ class DeployMAASRegionApplicationStep(DeployMachineApplicationStep):
             model,
             "maas-region-plan",
             f"{verb.capitalize()} MAAS Region",
-            f"{verb.capitalize()} MAAS Region",
+            f"{verb.capitalize()}ing MAAS Region",
             refresh,
         )
         self.preseed = deployment_preseed or {}

--- a/anvil-python/anvil/commands/maas_region.py
+++ b/anvil-python/anvil/commands/maas_region.py
@@ -60,6 +60,7 @@ class DeployMAASRegionApplicationStep(DeployMachineApplicationStep):
         deployment_preseed: dict[Any, Any] | None = None,
         accept_defaults: bool = False,
         refresh: bool = False,
+        verb: str = "Deploy",
     ):
         super().__init__(
             client,
@@ -69,8 +70,8 @@ class DeployMAASRegionApplicationStep(DeployMachineApplicationStep):
             APPLICATION,
             model,
             "maas-region-plan",
-            "Deploy MAAS Region",
-            "Deploying MAAS Region",
+            f"{verb.capitalize()} MAAS Region",
+            f"{verb.capitalize()} MAAS Region",
             refresh,
         )
         self.preseed = deployment_preseed or {}
@@ -237,5 +238,6 @@ def maas_region_upgrade_steps(
             model,
             deployment_preseed=preseed,
             refresh=True,
+            verb="Refresh",
         ),
     ]

--- a/anvil-python/anvil/commands/postgresql.py
+++ b/anvil-python/anvil/commands/postgresql.py
@@ -81,6 +81,7 @@ def postgresql_upgrade_steps(
             model,
             deployment_preseed=preseed,
             refresh=True,
+            verb="Refresh",
         ),
     ]
 
@@ -123,6 +124,7 @@ class DeployPostgreSQLApplicationStep(DeployMachineApplicationStep):
         deployment_preseed: dict[Any, Any] | None = None,
         accept_defaults: bool = False,
         refresh: bool = False,
+        verb: str = "Deploy",
     ):
         super().__init__(
             client,
@@ -132,8 +134,8 @@ class DeployPostgreSQLApplicationStep(DeployMachineApplicationStep):
             APPLICATION,
             model,
             "postgresql-plan",
-            "Deploy PostgreSQL",
-            "Deploying PostgreSQL",
+            f"{verb.capitalize()} PostgreSQL",
+            f"{verb.capitalize()}ing PostgreSQL",
             refresh,
         )
 

--- a/anvil-python/anvil/commands/upgrades/inter_channel.py
+++ b/anvil-python/anvil/commands/upgrades/inter_channel.py
@@ -245,19 +245,17 @@ class ChannelUpgradeCoordinator:
 
         Return the steps to complete this upgrade.
         """
-        plan: list[BaseStep] = []
+        plan: list[BaseStep] = [
+            UpgradePostgreSQLCharm(
+                self.client,
+                self.jhelper,
+                self.manifest,
+                self.deployment.infrastructure_model,
+            )
+        ]
         if self.client.cluster.list_nodes_by_role("haproxy"):
             plan.append(
                 UpgradeHAProxyCharm(
-                    self.client,
-                    self.jhelper,
-                    self.manifest,
-                    self.deployment.infrastructure_model,
-                )
-            )
-        if self.client.cluster.list_nodes_by_role("database"):
-            plan.append(
-                UpgradePostgreSQLCharm(
                     self.client,
                     self.jhelper,
                     self.manifest,

--- a/anvil-python/anvil/commands/upgrades/inter_channel.py
+++ b/anvil-python/anvil/commands/upgrades/inter_channel.py
@@ -262,18 +262,18 @@ class ChannelUpgradeCoordinator:
                     self.deployment.infrastructure_model,
                 )
             )
-        if self.client.cluster.list_nodes_by_role("agent"):
+        if self.client.cluster.list_nodes_by_role("region"):
             plan.append(
-                UpgradeMAASAgentCharm(
+                UpgradeMAASRegionCharm(
                     self.client,
                     self.jhelper,
                     self.manifest,
                     self.deployment.infrastructure_model,
                 )
             )
-        if self.client.cluster.list_nodes_by_role("region"):
+        if self.client.cluster.list_nodes_by_role("agent"):
             plan.append(
-                UpgradeMAASRegionCharm(
+                UpgradeMAASAgentCharm(
                     self.client,
                     self.jhelper,
                     self.manifest,

--- a/anvil-python/anvil/commands/upgrades/inter_channel.py
+++ b/anvil-python/anvil/commands/upgrades/inter_channel.py
@@ -245,32 +245,42 @@ class ChannelUpgradeCoordinator:
 
         Return the steps to complete this upgrade.
         """
-        plan = [
-            UpgradeHAProxyCharm(
-                self.client,
-                self.jhelper,
-                self.manifest,
-                self.deployment.infrastructure_model,
-            ),
-            UpgradePostgreSQLCharm(
-                self.client,
-                self.jhelper,
-                self.manifest,
-                self.deployment.infrastructure_model,
-            ),
-            # TODO: Don't allow updating MAAS until upgrade path sorted
-            # UpgradeMAASAgentCharm(
-            #     self.client,
-            #     self.jhelper,
-            #     self.manifest,
-            #     self.deployment.infrastructure_model,
-            # ),
-            # UpgradeMAASRegionCharm(
-            #     self.client,
-            #     self.jhelper,
-            #     self.manifest,
-            #     self.deployment.infrastructure_model,
-            # ),
-            UpgradePlugins(self.deployment, upgrade_release=True),
-        ]
+        plan: list[BaseStep] = []
+        if self.client.cluster.list_nodes_by_role("haproxy"):
+            plan.append(
+                UpgradeHAProxyCharm(
+                    self.client,
+                    self.jhelper,
+                    self.manifest,
+                    self.deployment.infrastructure_model,
+                )
+            )
+        if self.client.cluster.list_nodes_by_role("database"):
+            plan.append(
+                UpgradePostgreSQLCharm(
+                    self.client,
+                    self.jhelper,
+                    self.manifest,
+                    self.deployment.infrastructure_model,
+                )
+            )
+        if self.client.cluster.list_nodes_by_role("agent"):
+            plan.append(
+                UpgradeMAASAgentCharm(
+                    self.client,
+                    self.jhelper,
+                    self.manifest,
+                    self.deployment.infrastructure_model,
+                )
+            )
+        if self.client.cluster.list_nodes_by_role("region"):
+            plan.append(
+                UpgradeMAASRegionCharm(
+                    self.client,
+                    self.jhelper,
+                    self.manifest,
+                    self.deployment.infrastructure_model,
+                )
+            )
+        plan.append(UpgradePlugins(self.deployment, upgrade_release=True))
         return plan

--- a/anvil-python/anvil/commands/upgrades/inter_channel.py
+++ b/anvil-python/anvil/commands/upgrades/inter_channel.py
@@ -262,23 +262,24 @@ class ChannelUpgradeCoordinator:
                     self.deployment.infrastructure_model,
                 )
             )
-        if self.client.cluster.list_nodes_by_role("region"):
-            plan.append(
-                UpgradeMAASRegionCharm(
-                    self.client,
-                    self.jhelper,
-                    self.manifest,
-                    self.deployment.infrastructure_model,
-                )
-            )
-        if self.client.cluster.list_nodes_by_role("agent"):
-            plan.append(
-                UpgradeMAASAgentCharm(
-                    self.client,
-                    self.jhelper,
-                    self.manifest,
-                    self.deployment.infrastructure_model,
-                )
-            )
+        # TODO: Uncomment when charm upgrades merged
+        # if self.client.cluster.list_nodes_by_role("region"):
+        #     plan.append(
+        #         UpgradeMAASRegionCharm(
+        #             self.client,
+        #             self.jhelper,
+        #             self.manifest,
+        #             self.deployment.infrastructure_model,
+        #         )
+        #     )
+        # if self.client.cluster.list_nodes_by_role("agent"):
+        #     plan.append(
+        #         UpgradeMAASAgentCharm(
+        #             self.client,
+        #             self.jhelper,
+        #             self.manifest,
+        #             self.deployment.infrastructure_model,
+        #         )
+        #     )
         plan.append(UpgradePlugins(self.deployment, upgrade_release=True))
         return plan

--- a/anvil-python/anvil/commands/upgrades/intra_channel.py
+++ b/anvil-python/anvil/commands/upgrades/intra_channel.py
@@ -158,41 +158,45 @@ class LatestInChannelCoordinator:
         plan: list[BaseStep] = []
         plan.append(LatestInChannel(self.jhelper, self.manifest))
 
-        plan.extend(
-            haproxy_upgrade_steps(
-                self.client,
-                self.manifest,
-                self.jhelper,
-                self.deployment.infrastructure_model,
-                self.preseed,
+        if self.client.cluster.list_nodes_by_role("haproxy"):
+            plan.extend(
+                haproxy_upgrade_steps(
+                    self.client,
+                    self.manifest,
+                    self.jhelper,
+                    self.deployment.infrastructure_model,
+                    self.preseed,
+                )
             )
-        )
-        plan.extend(
-            postgresql_upgrade_steps(
-                self.client,
-                self.manifest,
-                self.jhelper,
-                self.deployment.infrastructure_model,
-                self.preseed,
+        if self.client.cluster.list_nodes_by_role("database"):
+            plan.extend(
+                postgresql_upgrade_steps(
+                    self.client,
+                    self.manifest,
+                    self.jhelper,
+                    self.deployment.infrastructure_model,
+                    self.preseed,
+                )
             )
-        )
-        plan.extend(
-            maas_region_upgrade_steps(
-                self.client,
-                self.manifest,
-                self.jhelper,
-                self.deployment.infrastructure_model,
-                self.preseed,
+        if self.client.cluster.list_nodes_by_role("agent"):
+            plan.extend(
+                maas_agent_upgrade_steps(
+                    self.client,
+                    self.manifest,
+                    self.jhelper,
+                    self.deployment.infrastructure_model,
+                    self.preseed,
             )
-        )
-        plan.extend(
-            maas_agent_upgrade_steps(
-                self.client,
-                self.manifest,
-                self.jhelper,
-                self.deployment.infrastructure_model,
             )
-        )
+        if self.client.cluster.list_nodes_by_role("region"):
+            plan.extend(
+                maas_region_upgrade_steps(
+                    self.client,
+                    self.manifest,
+                    self.jhelper,
+                    self.deployment.infrastructure_model,
+                )
+            )
 
         plan.append(UpgradePlugins(self.deployment, upgrade_release=False))
 

--- a/anvil-python/anvil/commands/upgrades/intra_channel.py
+++ b/anvil-python/anvil/commands/upgrades/intra_channel.py
@@ -177,9 +177,9 @@ class LatestInChannelCoordinator:
                     self.preseed,
                 )
             )
-        if self.client.cluster.list_nodes_by_role("agent"):
+        if self.client.cluster.list_nodes_by_role("region"):
             plan.extend(
-                maas_agent_upgrade_steps(
+                maas_region_upgrade_steps(
                     self.client,
                     self.manifest,
                     self.jhelper,
@@ -187,9 +187,9 @@ class LatestInChannelCoordinator:
                     self.preseed,
             )
             )
-        if self.client.cluster.list_nodes_by_role("region"):
+        if self.client.cluster.list_nodes_by_role("agent"):
             plan.extend(
-                maas_region_upgrade_steps(
+                maas_agent_upgrade_steps(
                     self.client,
                     self.manifest,
                     self.jhelper,

--- a/anvil-python/anvil/commands/upgrades/intra_channel.py
+++ b/anvil-python/anvil/commands/upgrades/intra_channel.py
@@ -185,7 +185,7 @@ class LatestInChannelCoordinator:
                     self.jhelper,
                     self.deployment.infrastructure_model,
                     self.preseed,
-            )
+                )
             )
         if self.client.cluster.list_nodes_by_role("agent"):
             plan.extend(

--- a/anvil-python/anvil/commands/upgrades/intra_channel.py
+++ b/anvil-python/anvil/commands/upgrades/intra_channel.py
@@ -157,20 +157,19 @@ class LatestInChannelCoordinator:
         """Return the upgrade plan."""
         plan: list[BaseStep] = []
         plan.append(LatestInChannel(self.jhelper, self.manifest))
+        plan.extend(
+            postgresql_upgrade_steps(
+                self.client,
+                self.manifest,
+                self.jhelper,
+                self.deployment.infrastructure_model,
+                self.preseed,
+            )
+        )
 
         if self.client.cluster.list_nodes_by_role("haproxy"):
             plan.extend(
                 haproxy_upgrade_steps(
-                    self.client,
-                    self.manifest,
-                    self.jhelper,
-                    self.deployment.infrastructure_model,
-                    self.preseed,
-                )
-            )
-        if self.client.cluster.list_nodes_by_role("database"):
-            plan.extend(
-                postgresql_upgrade_steps(
                     self.client,
                     self.manifest,
                     self.jhelper,


### PR DESCRIPTION
addresses the following points raised in #61:
- Blindly adding charms, rather than checking at least one node has the role for that charm
- Log messages containing "deploy" rather than "refresh"

Still requires modification to handle detecting deployment manifest changes before saving to the database.

May cause merge conflicts with #65