### PR TITLE
feat: TLS passthrough

### DIFF
--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -44,7 +44,6 @@ HAPROXY_UNIT_TIMEOUT = (
 HAPROXY_VALID_TLS_MODES = ["termination", "passthrough", "disabled"]
 
 
-
 def validate_cert_file(filepath: str) -> None:
     if filepath == "":
         return
@@ -209,13 +208,8 @@ class DeployHAProxyApplicationStep(DeployMachineApplicationStep):
             previous_answers=variables,
             accept_defaults=self.accept_defaults,
         )
-        cert_filepath = haproxy_config_bank.ssl_cert.ask()
-        variables["ssl_cert"] = cert_filepath
-        key_filepath = haproxy_config_bank.ssl_key.ask()
-        variables["ssl_key"] = key_filepath
-        tls_mode = ""
-        if variables["ssl_cert"] is not None:
-            tls_mode = haproxy_config_bank.tls_mode.ask()
+
+        tls_mode = haproxy_config_bank.tls_mode.ask()
         variables["tls_mode"] = tls_mode
         if tls_mode != "disabled":
             variables["ssl_cert"] = haproxy_config_bank.ssl_cert.ask()
@@ -233,13 +227,6 @@ class DeployHAProxyApplicationStep(DeployMachineApplicationStep):
             self.client, self._HAPROXY_CONFIG
         )
 
-        cert_filepath = variables["ssl_cert"]
-        key_filepath = variables["ssl_key"]
-        if cert_filepath != "" and key_filepath != "":
-            with open(cert_filepath) as cert_file:
-                variables["ssl_cert_content"] = cert_file.read()
-            with open(key_filepath) as key_file:
-                variables["ssl_key_content"] = key_file.read()
         if variables["tls_mode"] != "disabled":
             variables["haproxy_port"] = 443
             variables["haproxy_services_yaml"] = self.get_tls_services_yaml(

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -75,9 +75,9 @@ def validate_cacert_chain(filepath: str) -> None:
     if filepath == "":
         return
     try:
-        # just make sure we can open the file
-        with open(filepath):
-            pass
+        with open(filepath) as f:
+            if "BEGIN CERTIFICATE" not in f.read():
+                raise ValueError("Invalid CA certificate file")
     except FileNotFoundError:
         raise ValueError(f"{filepath} does not exist")
     except PermissionError:
@@ -115,7 +115,7 @@ def tls_questions(tls_modes: list[str]) -> dict[str, questions.PromptQuestion]:
             validation_function=validate_key_file,
         ),
         "ssl_cacert": questions.PromptQuestion(
-            "Path to cacert chain, for use with self-signed ssl certificates (enter nothing to skip)",
+            "Path to CA cert chain, for use with self-signed SSL certificates (enter nothing to skip)",
             default_value="",
             validation_function=validate_cacert_chain,
         ),
@@ -253,9 +253,6 @@ class DeployHAProxyApplicationStep(DeployMachineApplicationStep):
                 variables["ssl_cert_content"] = cert_file.read()
             with open(variables["ssl_key"]) as key_file:
                 variables["ssl_key_content"] = key_file.read()
-            if variables["ssl_cacert"]:
-                with open(variables["ssl_cacert"]) as cacert_file:
-                    variables["ssl_cacert_content"] = cacert_file.read()
         else:
             variables["haproxy_port"] = 80
 

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -15,7 +15,6 @@
 
 import ipaddress
 import logging
-import os.path
 from typing import Any, Callable, List
 
 from rich.console import Console
@@ -49,12 +48,12 @@ HAPROXY_VALID_TLS_MODES = ["termination", "passthrough", "disabled"]
 def validate_cert_file(filepath: str) -> None:
     if filepath == "":
         return
-    if not os.path.isfile(filepath):
-        raise ValueError(f"{filepath} does not exist")
     try:
         with open(filepath) as f:
             if "BEGIN CERTIFICATE" not in f.read():
                 raise ValueError("Invalid certificate file")
+    except FileNotFoundError:
+        raise ValueError(f"{filepath} does not exist")
     except PermissionError:
         raise ValueError(f"Permission denied when trying to read {filepath}")
 
@@ -62,12 +61,12 @@ def validate_cert_file(filepath: str) -> None:
 def validate_key_file(filepath: str) -> None:
     if filepath == "":
         return
-    if not os.path.isfile(filepath):
-        raise ValueError(f"{filepath} does not exist")
     try:
         with open(filepath) as f:
             if "BEGIN PRIVATE KEY" not in f.read():
                 raise ValueError("Invalid key file")
+    except FileNotFoundError:
+        raise ValueError(f"{filepath} does not exist")
     except PermissionError:
         raise ValueError(f"Permission denied when trying to read {filepath}")
 
@@ -75,12 +74,12 @@ def validate_key_file(filepath: str) -> None:
 def validate_cacert_chain(filepath: str) -> None:
     if filepath == "":
         return
-    if not os.path.isfile(filepath):
-        raise ValueError(f"{filepath} does not exist")
     try:
         # just make sure we can open the file
         with open(filepath):
             pass
+    except FileNotFoundError:
+        raise ValueError(f"{filepath} does not exist")
     except PermissionError:
         raise ValueError(f"Permission denied when trying to read {filepath}")
 

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -43,7 +43,6 @@ HAPROXY_UNIT_TIMEOUT = (
     1200  # 15 minutes, adding / removing units can take a long time
 )
 VALID_TLS_MODES = ["termination", "passthrough"]
-LOG = logging.getLogger(__name__)
 
 
 <<<<<<< HEAD

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -12,7 +12,6 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import ipaddress
 import logging
 import os.path
@@ -130,6 +129,7 @@ class DeployHAProxyApplicationStep(DeployMachineApplicationStep):
         )
         self.preseed = deployment_preseed or {}
         self.accept_defaults = accept_defaults
+        self.variables: dict[str, Any] = {"charm_haproxy_config": {}}
 
     def get_application_timeout(self) -> int:
         return HAPROXY_APP_TIMEOUT

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -12,6 +12,7 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import ipaddress
 import logging
 import os.path

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -29,6 +29,7 @@ from sunbeam.jobs.steps import (
     AddMachineUnitsStep,
     DeployMachineApplicationStep,
 )
+from sunbeam.utils import get_local_ip_by_default_route
 
 from anvil.jobs.manifest import Manifest
 from anvil.jobs.steps import RemoveMachineUnitStep

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -29,7 +29,6 @@ from sunbeam.jobs.steps import (
     AddMachineUnitsStep,
     DeployMachineApplicationStep,
 )
-from sunbeam.utils import get_local_ip_by_default_route
 
 from anvil.jobs.manifest import Manifest
 from anvil.jobs.steps import RemoveMachineUnitStep

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -71,7 +71,6 @@ def validate_key_file(filepath: str) -> None:
     except PermissionError:
         raise ValueError(f"Permission denied when trying to read {filepath}")
 
-
 def validate_virtual_ip(value: str) -> None:
     """We allow passing an empty IP for virtual_ip"""
     if value == "":

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -78,10 +78,9 @@ def validate_cacert_chain(filepath: str) -> None:
     if not os.path.isfile(filepath):
         raise ValueError(f"{filepath} does not exist")
     try:
+        # just make sure we can open the file
         with open(filepath) as f:
-            # TODO: better validation
-            if "BEGIN" not in f.read():
-                raise ValueError("Invalid cacert chain file")
+            pass
     except PermissionError:
         raise ValueError(f"Permission denied when trying to read {filepath}")
 
@@ -122,7 +121,7 @@ def tls_questions(tls_modes: list[str]) -> dict[str, questions.PromptQuestion]:
             validation_function=validate_cacert_chain,
         ),
         "tls_mode": questions.PromptQuestion(
-            'TLS termination at HA Proxy ("termination"), passthrough to MAAS ("passthrough"), or no TLS ("disabled")?',
+            f"TLS mode: {tls_modes}?",
             default_value="disabled",
             validation_function=get_validate_tls_mode_fn(tls_modes),
         ),

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -79,7 +79,7 @@ def validate_cacert_chain(filepath: str) -> None:
         raise ValueError(f"{filepath} does not exist")
     try:
         # just make sure we can open the file
-        with open(filepath) as f:
+        with open(filepath):
             pass
     except PermissionError:
         raise ValueError(f"Permission denied when trying to read {filepath}")

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -119,7 +119,7 @@ def tls_questions(tls_modes: list[str]) -> dict[str, questions.PromptQuestion]:
             validation_function=validate_cacert_chain,
         ),
         "tls_mode": questions.PromptQuestion(
-            f"TLS mode: {tls_modes}?",
+            f"TLS mode: {tls_modes}",
             default_value="disabled",
             validation_function=get_validate_tls_mode_fn(tls_modes),
         ),

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -130,7 +130,6 @@ class DeployHAProxyApplicationStep(DeployMachineApplicationStep):
         )
         self.preseed = deployment_preseed or {}
         self.accept_defaults = accept_defaults
-        self.use_tls_termination = False
 
     def get_application_timeout(self) -> int:
         return HAPROXY_APP_TIMEOUT
@@ -168,7 +167,6 @@ class DeployHAProxyApplicationStep(DeployMachineApplicationStep):
             previous_answers=variables,
             accept_defaults=self.accept_defaults,
         )
-
         cert_filepath = haproxy_config_bank.ssl_cert.ask()
         variables["ssl_cert"] = cert_filepath
         key_filepath = haproxy_config_bank.ssl_key.ask()

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -129,7 +129,7 @@ class DeployHAProxyApplicationStep(DeployMachineApplicationStep):
         )
         self.preseed = deployment_preseed or {}
         self.accept_defaults = accept_defaults
-        self.variables: dict[str, Any] = {"charm_haproxy_config": {}}
+        self.use_tls_termination = False
 
     def get_application_timeout(self) -> int:
         return HAPROXY_APP_TIMEOUT

--- a/anvil-python/anvil/commands/maas_region.py
+++ b/anvil-python/anvil/commands/maas_region.py
@@ -13,34 +13,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import Any, List
 
 from sunbeam.clusterd.client import Client
-from sunbeam.commands.terraform import TerraformInitStep, TerraformException
+from sunbeam.commands.terraform import TerraformException, TerraformInitStep
 from sunbeam.jobs import questions
-from sunbeam.jobs.common import BaseStep
+from sunbeam.jobs.common import BaseStep, ResultType
 from sunbeam.jobs.juju import JujuHelper
 from sunbeam.jobs.steps import (
     AddMachineUnitsStep,
     DeployMachineApplicationStep,
 )
 
-from anvil.commands.haproxy import HAPROXY_CONFIG_KEY
+from anvil.commands.haproxy import HAPROXY_CONFIG_KEY, tls_questions
 from anvil.jobs.manifest import Manifest
 from anvil.jobs.steps import RemoveMachineUnitStep
 
+LOG = logging.getLogger(__name__)
+
 APPLICATION = "maas-region"
 CONFIG_KEY = "TerraformVarsMaasregionPlan"
+MAASREGION_CONFIG_KEY = "TerraformVarsMaasregion"
 MAASREGION_APP_TIMEOUT = (
     180  # 3 minutes, managing the application should be fast
 )
 MAASREGION_UNIT_TIMEOUT = (
     1200  # 15 minutes, adding / removing units can take a long time
 )
+# If tls_mode is being asked here, haproxy is not enabled.
+# So, TLS termination is not a valid config
+MAAS_REGION_VALID_TLS_MODES = ["passthrough", "disabled"]
 
 
 class DeployMAASRegionApplicationStep(DeployMachineApplicationStep):
     """Deploy MAAS Region application using Terraform"""
+
+    _MAASREGION_CONFIG = MAASREGION_CONFIG_KEY
 
     def __init__(
         self,
@@ -48,6 +57,8 @@ class DeployMAASRegionApplicationStep(DeployMachineApplicationStep):
         manifest: Manifest,
         jhelper: JujuHelper,
         model: str,
+        deployment_preseed: dict[Any, Any] | None = None,
+        accept_defaults: bool = False,
         refresh: bool = False,
     ):
         super().__init__(
@@ -62,9 +73,54 @@ class DeployMAASRegionApplicationStep(DeployMachineApplicationStep):
             "Deploying MAAS Region",
             refresh,
         )
+        self.preseed = deployment_preseed or {}
+        self.accept_defaults = accept_defaults
 
     def get_application_timeout(self) -> int:
         return MAASREGION_APP_TIMEOUT
+
+    def has_prompts(self) -> bool:
+        if self.refresh:
+            return False
+        skip_result = self.is_skip()
+        if skip_result.result_type == ResultType.SKIPPED:
+            return False
+        elif self.client.cluster.list_nodes_by_role("haproxy"):
+            return False
+        return True
+
+    def prompt(self, console: questions.Console | None = None) -> None:
+        variables = questions.load_answers(
+            self.client, self._MAASREGION_CONFIG
+        )
+        variables.setdefault("ssl_cert", "")
+        variables.setdefault("ssl_key", "")
+        variables.setdefault("ssl_cacert", "")
+        variables.setdefault("tls_mode", "disabled")
+
+        self.preseed.setdefault("ssl_cert", "")
+        self.preseed.setdefault("ssl_key", "")
+        self.preseed.setdefault("ssl_cacert", "")
+        self.preseed.setdefault("tls_mode", "disabled")
+
+        maas_region_config_bank = questions.QuestionBank(
+            questions=tls_questions(MAAS_REGION_VALID_TLS_MODES),
+            console=console,
+            preseed=self.preseed.get("maas-region"),
+            previous_answers=variables,
+            accept_defaults=self.accept_defaults,
+        )
+        tls_mode = maas_region_config_bank.tls_mode.ask()
+        variables["tls_mode"] = tls_mode
+        if tls_mode == "passthrough":
+            variables["ssl_cert"] = maas_region_config_bank.ssl_cert.ask()
+            variables["ssl_key"] = maas_region_config_bank.ssl_key.ask()
+            variables["ssl_cacert"] = maas_region_config_bank.ssl_cacert.ask()
+
+        LOG.debug(variables)
+        questions.write_answers(
+            self.client, self._MAASREGION_CONFIG, variables
+        )
 
     def extra_tfvars(self) -> dict[str, Any]:
         enable_haproxy = (
@@ -73,21 +129,26 @@ class DeployMAASRegionApplicationStep(DeployMachineApplicationStep):
             else False
         )
         variables: dict[str, Any] = {"enable_haproxy": enable_haproxy}
-        haproxy_vars: dict[str, Any] = questions.load_answers(
-            self.client, HAPROXY_CONFIG_KEY
-        )
-
-        variables["tls_mode"] = haproxy_vars["tls_mode"]
+        answers: dict[str, Any] = {}
+        if enable_haproxy:
+            answers = questions.load_answers(self.client, HAPROXY_CONFIG_KEY)
+        else:
+            answers = questions.load_answers(
+                self.client, self._MAASREGION_CONFIG
+            )
+        variables["tls_mode"] = answers["tls_mode"]
         if variables["tls_mode"] == "passthrough":
-            try:
-                opening = "certificate"
-                with open(variables["ssl_cert"]) as cert_file:
-                    variables["ssl_cert_content"] = cert_file.read()
-                opening = "private key"
-                with open(variables["ssl_key"]) as key_file:
-                    variables["ssl_key_content"] = key_file.read()
-            except FileNotFoundError:
-                raise TerraformException(f"SSL {opening} not found")
+            if not answers["ssl_cert"] or not answers["ssl_key"]:
+                raise TerraformException(
+                    "Both ssl_cert and ssl_key must be provided when enabling TLS"
+                )
+            with open(answers["ssl_cert"]) as cert_file:
+                variables["ssl_cert_content"] = cert_file.read()
+            with open(answers["ssl_key"]) as key_file:
+                variables["ssl_key_content"] = key_file.read()
+            if answers["ssl_cacert"]:
+                with open(answers["ssl_cacert"]) as cacert_file:
+                    variables["ssl_cacert_content"] = cacert_file.read()
         return variables
 
 
@@ -143,10 +204,19 @@ def maas_region_install_steps(
     jhelper: JujuHelper,
     model: str,
     fqdn: str,
+    accept_defaults: bool,
+    preseed: dict[Any, Any],
 ) -> List[BaseStep]:
     return [
         TerraformInitStep(manifest.get_tfhelper("maas-region-plan")),
-        DeployMAASRegionApplicationStep(client, manifest, jhelper, model),
+        DeployMAASRegionApplicationStep(
+            client,
+            manifest,
+            jhelper,
+            model,
+            deployment_preseed=preseed,
+            accept_defaults=accept_defaults,
+        ),
         AddMAASRegionUnitsStep(client, fqdn, jhelper, model),
     ]
 
@@ -156,10 +226,16 @@ def maas_region_upgrade_steps(
     manifest: Manifest,
     jhelper: JujuHelper,
     model: str,
+    preseed: dict[Any, Any],
 ) -> List[BaseStep]:
     return [
         TerraformInitStep(manifest.get_tfhelper("maas-region-plan")),
         DeployMAASRegionApplicationStep(
-            client, manifest, jhelper, model, refresh=True
+            client,
+            manifest,
+            jhelper,
+            model,
+            deployment_preseed=preseed,
+            refresh=True,
         ),
     ]

--- a/anvil-python/anvil/commands/upgrades/intra_channel.py
+++ b/anvil-python/anvil/commands/upgrades/intra_channel.py
@@ -182,6 +182,7 @@ class LatestInChannelCoordinator:
                 self.manifest,
                 self.jhelper,
                 self.deployment.infrastructure_model,
+                self.preseed,
             )
         )
         plan.extend(

--- a/anvil-python/anvil/provider/local/commands.py
+++ b/anvil-python/anvil/provider/local/commands.py
@@ -305,6 +305,8 @@ def bootstrap(
                 jhelper,
                 deployment.infrastructure_model,
                 fqdn,
+                accept_defaults,
+                preseed,
             )
         )
     if is_agent_node:
@@ -495,6 +497,8 @@ def join(
                 jhelper,
                 deployment.infrastructure_model,
                 name,
+                accept_defaults,
+                preseed,
             )
         )
         plan2.append(

--- a/anvil-python/anvil/versions.py
+++ b/anvil-python/anvil/versions.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-MAAS_REGION_CHANNEL = "3.5/edge"
+MAAS_REGION_CHANNEL = "latest/edge/wyatt-test"
 MAAS_AGENT_CHANNEL = "3.5/edge"
 POSTGRESQL_CHANNEL = "14/stable"
 HAPROXY_CHANNEL = "latest/stable"

--- a/anvil-python/anvil/versions.py
+++ b/anvil-python/anvil/versions.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-MAAS_REGION_CHANNEL = "latest/edge/wyatt-test"
+MAAS_REGION_CHANNEL = "3.5/edge"
 MAAS_AGENT_CHANNEL = "3.5/edge"
 POSTGRESQL_CHANNEL = "14/stable"
 HAPROXY_CHANNEL = "latest/stable"

--- a/cloud/etc/deploy-maas-region/main.tf
+++ b/cloud/etc/deploy-maas-region/main.tf
@@ -32,8 +32,8 @@ data "juju_model" "machine_model" {
 
 locals {
   tls_mode = var.tls_mode != "" ? { tls_mode = var.tls_mode } : {}
-  ssl_cert = var.ssl_cert != "" ? { ssl_cert = var.ssl_cert } : {}
-  ssl_key  = var.ssl_key != "" ? { ssl_key = var.ssl_key } : {}
+  ssl_cert_content = var.ssl_cert_content != "" ? { ssl_cert_content = var.ssl_cert_content } : {}
+  ssl_key_content  = var.ssl_key_content != "" ? { ssl_key_content = var.ssl_key_content } : {}
 }
 
 resource "juju_application" "maas-region" {
@@ -50,8 +50,8 @@ resource "juju_application" "maas-region" {
 
   config = merge(
     local.tls_mode,
-    local.ssl_cert,
-    local.ssl_key,
+    local.ssl_cert_content,
+    local.ssl_key_content,
     var.charm_maas_region_config,
   )
 }

--- a/cloud/etc/deploy-maas-region/main.tf
+++ b/cloud/etc/deploy-maas-region/main.tf
@@ -32,6 +32,8 @@ data "juju_model" "machine_model" {
 
 locals {
   tls_mode = var.tls_mode != "" ? { tls_mode = var.tls_mode } : {}
+  ssl_cert = var.ssl_cert != "" ? { ssl_cert = var.ssl_cert } : {}
+  ssl_key  = var.ssl_key != "" ? { ssl_key = var.ssl_key } : {}
 }
 
 resource "juju_application" "maas-region" {
@@ -48,6 +50,8 @@ resource "juju_application" "maas-region" {
 
   config = merge(
     local.tls_mode,
+    local.ssl_cert,
+    local.ssl_key,
     var.charm_maas_region_config,
   )
 }

--- a/cloud/etc/deploy-maas-region/main.tf
+++ b/cloud/etc/deploy-maas-region/main.tf
@@ -34,6 +34,7 @@ locals {
   tls_mode = var.tls_mode != "" ? { tls_mode = var.tls_mode } : {}
   ssl_cert_content = var.ssl_cert_content != "" ? { ssl_cert_content = var.ssl_cert_content } : {}
   ssl_key_content  = var.ssl_key_content != "" ? { ssl_key_content = var.ssl_key_content } : {}
+  ssl_cacert_content  = var.ssl_cacert_content != "" ? { ssl_cacert_content = var.ssl_cacert_content } : {}
 }
 
 resource "juju_application" "maas-region" {
@@ -52,6 +53,7 @@ resource "juju_application" "maas-region" {
     local.tls_mode,
     local.ssl_cert_content,
     local.ssl_key_content,
+    local.ssl_cacert_content,
     var.charm_maas_region_config,
   )
 }

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -49,7 +49,7 @@ variable "enable_haproxy" {
 }
 
 variable "tls_mode" {
-  description = "TLS Mode for MAAS Region charm ('', 'termination', or 'passthrough')"
+  description = "TLS Mode for MAAS Region charm ('disabled', 'termination', or 'passthrough')"
   type        = string
   default     = ""
 }

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -59,3 +59,15 @@ variable "tls_mode" {
   type        = string
   default     = ""
 }
+
+variable "ssl_cert" {
+  description = "Path to SSL certificate for tls_mode=passthrough"
+  type        = string
+  default     = ""
+}
+
+variable "ssl_key" {
+  description = "Path to SSL private key for tls_mode=passthrough"
+  type        = string
+  default     = ""
+}

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -65,3 +65,9 @@ variable "ssl_key_content" {
   type        = string
   default     = ""
 }
+
+variable "ssl_cacert_content" {
+  description = "CA Cert chain for self-signed certificates, requires tls_mode=passthrough"
+  type        = string
+  default     = ""
+}

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -53,3 +53,9 @@ variable "tls_mode" {
   type        = string
   default     = ""
 }
+
+variable "tls_mode" {
+  description = "TLS Mode for MAAS Region charm ('', 'termination', or 'passthrough')"
+  type        = string
+  default     = ""
+}

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -60,14 +60,14 @@ variable "tls_mode" {
   default     = ""
 }
 
-variable "ssl_cert" {
-  description = "Path to SSL certificate for tls_mode=passthrough"
+variable "ssl_cert_content" {
+  description = "SSL certificate for tls_mode=passthrough"
   type        = string
   default     = ""
 }
 
-variable "ssl_key" {
-  description = "Path to SSL private key for tls_mode=passthrough"
+variable "ssl_key_content" {
+  description = "SSL private key for tls_mode=passthrough"
   type        = string
   default     = ""
 }

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -51,7 +51,7 @@ variable "enable_haproxy" {
 variable "tls_mode" {
   description = "TLS Mode for MAAS Region charm ('disabled', 'termination', or 'passthrough')"
   type        = string
-  default     = ""
+  default     = "disabled"
 }
 
 variable "ssl_cert_content" {

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -54,12 +54,6 @@ variable "tls_mode" {
   default     = ""
 }
 
-variable "tls_mode" {
-  description = "TLS Mode for MAAS Region charm ('', 'termination', or 'passthrough')"
-  type        = string
-  default     = ""
-}
-
 variable "ssl_cert_content" {
   description = "SSL certificate for tls_mode=passthrough"
   type        = string


### PR DESCRIPTION
Adds configuration for passing encrypted requests through HAProxy, to MAAS. 

Requires merging of https://github.com/canonical/maas-charms/pull/220. Until it is merged, you can use `latest/edge/passthrough-test` for the maas-region charm channel