### PR TITLE
feat: accept defaults for non manifest parameters when a manifest is passed

### DIFF
--- a/anvil-python/anvil/provider/local/commands.py
+++ b/anvil-python/anvil/provider/local/commands.py
@@ -195,6 +195,9 @@ def bootstrap(
             manifest_data=manifest_data or {},
             include_defaults=True,
         )
+
+        # don't ask deployment questions if we pass a manifest
+        accept_defaults = True
     else:
         manifest_obj = Manifest.get_default_manifest(deployment)
 


### PR DESCRIPTION
addresses #68 

If a manifest is passed, we force accept_defaults to True, preventing it asking questions. This should result in the manifest configuration being used, or the default values if the value is not present in the manifest.