### PR TITLE
fix: update TF provider and switch haproxy stable channel

### DIFF
--- a/cloud/etc/deploy-haproxy/main.tf
+++ b/cloud/etc/deploy-haproxy/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.11.0"
+      version = "= 0.15.1"
     }
   }
 

--- a/cloud/etc/deploy-haproxy/variables.tf
+++ b/cloud/etc/deploy-haproxy/variables.tf
@@ -16,7 +16,7 @@
 variable "charm_haproxy_channel" {
   description = "Operator channel for HAProxy deployment"
   type        = string
-  default     = "14/stable"
+  default     = "latest/stable"
 }
 
 variable "charm_haproxy_revision" {

--- a/cloud/etc/deploy-maas-agent/main.tf
+++ b/cloud/etc/deploy-maas-agent/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.11.0"
+      version = "= 0.15.1"
     }
   }
 

--- a/cloud/etc/deploy-maas-region/main.tf
+++ b/cloud/etc/deploy-maas-region/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.11.0"
+      version = "= 0.15.1"
     }
   }
 

--- a/cloud/etc/deploy-postgresql/main.tf
+++ b/cloud/etc/deploy-postgresql/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.11.0"
+      version = "= 0.15.1"
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/canonical/maas-anvil/issues/80 and https://github.com/canonical/maas-anvil/issues/79

* Updates the Juju Terraform provider to 0.15.1
* Switches the haproxy channel to latest/stable

Bootstrapped a node locally as a test and the charms idled.