### PR TITLE
fix: workaround for LP-2097079

### DIFF
--- a/cloud/etc/deploy-postgresql/main.tf
+++ b/cloud/etc/deploy-postgresql/main.tf
@@ -52,5 +52,10 @@ resource "juju_application" "postgresql" {
     base     = "ubuntu@22.04"
   }
 
-  config = merge(local.max_connections, var.charm_postgresql_config)
+  config = merge(
+    local.max_connections,
+    # workaround for https://bugs.launchpad.net/maas/+bug/2097079
+    { "plugin_audit_enable" : false },
+    var.charm_postgresql_config
+  )
 }


### PR DESCRIPTION
Until a proper fix is released for https://bugs.launchpad.net/maas/+bug/2097079 and after the postgresql revision 553 was released to 14/stable, we need to start the postgresql with the pgaudit plugin set to disabled.