### PR TITLE
chore: upgrade Juju to 3.6 LTS

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-amd64:
     name: Build snap amd64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       snap: ${{ steps.snapcraft.outputs.snap }}
     steps:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,7 +19,7 @@ jobs:
   # TODO (@skatsaounis): Uncomment when unit tests are implemented
   # unit-test:
   #   name: Unit tests
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-22.04
   #   steps:
   #     - name: Checkout
   #       uses: actions/checkout@v4

--- a/anvil-python/anvil/commands/prepare_node.py
+++ b/anvil-python/anvil/commands/prepare_node.py
@@ -21,7 +21,7 @@ from anvil.utils import FormatEpilogCommand
 console = Console()
 
 
-JUJU_CHANNEL = "3.4/stable"
+JUJU_CHANNEL = "3.6/stable"
 SUPPORTED_RELEASE = "jammy"
 
 PREPARE_NODE_TEMPLATE = f"""#!/bin/bash

--- a/anvil-python/anvil/commands/refresh.py
+++ b/anvil-python/anvil/commands/refresh.py
@@ -82,7 +82,7 @@ def refresh(
     manifest = None
     if manifest_path:
         try:
-            with click.open_file(manifest_path) as file:  # type: ignore
+            with click.open_file(manifest_path) as file:
                 manifest_data = yaml.safe_load(file)
         except (OSError, yaml.YAMLError) as e:
             LOG.debug(e)

--- a/anvil-python/anvil/provider/local/commands.py
+++ b/anvil-python/anvil/provider/local/commands.py
@@ -221,7 +221,7 @@ def bootstrap(
     manifest_obj = None
     if manifest:
         try:
-            with click.open_file(manifest) as file:  # type: ignore
+            with click.open_file(manifest) as file:
                 manifest_data = yaml.safe_load(file)
         except (OSError, yaml.YAMLError) as e:
             LOG.debug(e)

--- a/anvil-python/pyproject.toml
+++ b/anvil-python/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "pydantic==1.10.14",
   "rich",
   "snap-helpers@ git+https://github.com/skatsaounis/snap-helpers",
-  "sunbeam@ git+https://github.com/skatsaounis/snap-openstack@devel/juju-lts#subdirectory=sunbeam-python",
+  "sunbeam@ git+https://github.com/canonical/snap-openstack@unmaintained/juju-lts-anvil#subdirectory=sunbeam-python",
 ]
 [project.optional-dependencies]
 testing = [

--- a/anvil-python/pyproject.toml
+++ b/anvil-python/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "pydantic==1.10.14",
   "rich",
   "snap-helpers@ git+https://github.com/skatsaounis/snap-helpers",
-  "sunbeam@ git+https://github.com/canonical/snap-openstack@anvil-0.1#subdirectory=sunbeam-python",
+  "sunbeam@ git+https://github.com/skatsaounis/snap-openstack@devel/juju-lts#subdirectory=sunbeam-python",
 ]
 [project.optional-dependencies]
 testing = [

--- a/anvil-python/requirements.txt
+++ b/anvil-python/requirements.txt
@@ -100,7 +100,7 @@ markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.3.2
+multidict==6.2.0
     # via
     #   aiohttp
     #   yarl
@@ -150,7 +150,7 @@ pygments==2.19.1
     # via rich
 pymacaroons==0.13.0
     # via macaroonbakery
-pymongo==4.11.3
+pymongo==4.12.0
     # via python-libmaas
 pynacl==1.5.0
     # via
@@ -220,7 +220,7 @@ snap-helpers @ git+https://github.com/skatsaounis/snap-helpers
     #   sunbeam
 sniffio==1.3.1
     # via anyio
-sunbeam @ git+https://github.com/skatsaounis/snap-openstack@devel/juju-lts#subdirectory=sunbeam-python
+sunbeam @ git+https://github.com/canonical/snap-openstack@unmaintained/juju-lts-anvil#subdirectory=sunbeam-python
     # via anvil (pyproject.toml)
 terminaltables==3.1.10
     # via python-libmaas
@@ -246,7 +246,7 @@ websocket-client==1.8.0
     # via kubernetes
 websockets==15.0.1
     # via juju
-yarl==1.18.3
+yarl==1.19.0
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/anvil-python/requirements.txt
+++ b/anvil-python/requirements.txt
@@ -4,84 +4,90 @@
 #
 #    pip-compile --output-file=requirements.txt pyproject.toml
 #
-aiohttp==3.10.2
-    # via python-libmaas
-aiosignal==1.3.1
+aiohappyeyeballs==2.6.1
     # via aiohttp
-anyio==4.3.0
+aiohttp==3.11.16
+    # via python-libmaas
+aiosignal==1.3.2
+    # via aiohttp
+anyio==4.9.0
     # via httpx
-argcomplete==3.2.3
+argcomplete==3.6.2
     # via python-libmaas
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via aiohttp
-attrs==23.2.0
+attrs==25.3.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
-bcrypt==4.1.2
+backports-datetime-fromisoformat==2.0.3
+    # via juju
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.3.0
     # via paramiko
-cachetools==5.3.3
+cachetools==5.5.2
     # via google-auth
-certifi==2024.7.4
+certifi==2025.1.31
     # via
     #   httpcore
     #   httpx
     #   kubernetes
     #   requests
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.3.2
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via sunbeam
 colorclass==2.2.2
     # via python-libmaas
-croniter==2.0.3
+croniter==6.0.0
     # via sunbeam
-cryptography==44.0.1
+cryptography==44.0.2
     # via paramiko
-dnspython==2.6.1
+dnspython==2.7.0
     # via pymongo
-exceptiongroup==1.2.0
+exceptiongroup==1.2.2
     # via anyio
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-gitdb==4.0.11
+gitdb==4.0.12
     # via gitpython
-gitpython==3.1.43
+gitpython==3.1.44
     # via sunbeam
-google-auth==2.29.0
+google-auth==2.38.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.28.1
     # via lightkube
-hvac==2.1.0
+hvac==2.3.0
     # via juju
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
     #   yarl
-jsonschema==4.21.1
+jsonschema==4.23.0
     # via sunbeam
-jsonschema-specifications==2023.12.1
+jsonschema-specifications==2024.10.1
     # via jsonschema
-juju==3.4.0.0
+juju==3.6.1.1
     # via sunbeam
-kubernetes==29.0.0
+kubernetes==30.1.0
     # via juju
-lightkube==0.15.2
+lightkube==0.17.1
     # via sunbeam
-lightkube-models==1.29.0.7
+lightkube-models==1.32.0.8
     # via
     #   lightkube
     #   sunbeam
@@ -94,7 +100,7 @@ markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.0.5
+multidict==6.3.2
     # via
     #   aiohttp
     #   yarl
@@ -107,28 +113,32 @@ oauthlib==3.2.2
     #   kubernetes
     #   python-libmaas
     #   requests-oauthlib
-packaging==24.0
+packaging==24.2
     # via juju
-paramiko==3.4.0
+paramiko==3.5.1
     # via juju
-pbr==6.0.0
+pbr==6.1.1
     # via sunbeam
 petname==2.6
     # via sunbeam
 pexpect==4.9.0
     # via sunbeam
-protobuf==5.26.1
+propcache==0.3.1
+    # via
+    #   aiohttp
+    #   yarl
+protobuf==6.30.2
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
 pwgen==0.8.2.post0
     # via sunbeam
-pyasn1==0.6.0
+pyasn1==0.6.1
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.0
+pyasn1-modules==0.4.2
     # via google-auth
 pycparser==2.22
     # via cffi
@@ -136,11 +146,11 @@ pydantic==1.10.14
     # via
     #   anvil (pyproject.toml)
     #   sunbeam
-pygments==2.17.2
+pygments==2.19.1
     # via rich
 pymacaroons==0.13.0
     # via macaroonbakery
-pymongo==4.6.3
+pymongo==4.11.3
     # via python-libmaas
 pynacl==1.5.0
     # via
@@ -148,10 +158,8 @@ pynacl==1.5.0
     #   paramiko
     #   pymacaroons
 pyrfc3339==1.1
-    # via
-    #   juju
-    #   macaroonbakery
-pyroute2==0.7.12
+    # via macaroonbakery
+pyroute2==0.9.1
     # via sunbeam
 python-dateutil==2.9.0.post0
     # via
@@ -159,12 +167,12 @@ python-dateutil==2.9.0.post0
     #   kubernetes
 python-libmaas==0.6.8
     # via sunbeam
-pytz==2024.1
+pytz==2025.2
     # via
     #   croniter
     #   pyrfc3339
     #   python-libmaas
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   juju
     #   kubernetes
@@ -172,11 +180,11 @@ pyyaml==6.0.1
     #   python-libmaas
     #   snap-helpers
     #   sunbeam
-referencing==0.34.0
+referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.31.0
+requests==2.32.3
     # via
     #   hvac
     #   kubernetes
@@ -186,55 +194,60 @@ requests==2.31.0
     #   sunbeam
 requests-oauthlib==2.0.0
     # via kubernetes
-requests-unixsocket==0.3.0
+requests-unixsocket==0.4.1
     # via sunbeam
-rich==13.7.1
+rich==14.0.0
     # via
     #   anvil (pyproject.toml)
     #   sunbeam
-rpds-py==0.18.0
+rpds-py==0.24.0
     # via
     #   jsonschema
     #   referencing
 rsa==4.9
     # via google-auth
-six==1.16.0
+six==1.17.0
     # via
     #   kubernetes
     #   macaroonbakery
     #   pymacaroons
     #   python-dateutil
-smmap==5.0.1
+smmap==5.0.2
     # via gitdb
 snap-helpers @ git+https://github.com/skatsaounis/snap-helpers
     # via
     #   anvil (pyproject.toml)
     #   sunbeam
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
-sunbeam @ git+https://github.com/canonical/snap-openstack@anvil-0.1#subdirectory=sunbeam-python
+    # via anyio
+sunbeam @ git+https://github.com/skatsaounis/snap-openstack@devel/juju-lts#subdirectory=sunbeam-python
     # via anvil (pyproject.toml)
 terminaltables==3.1.10
     # via python-libmaas
 toposort==1.10
     # via juju
-typing-extensions==4.10.0
+typing-extensions==4.13.1
     # via
     #   anyio
+    #   juju
+    #   multidict
     #   pydantic
+    #   referencing
+    #   rich
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==1.26.19
+urllib3==1.26.20
     # via
     #   kubernetes
     #   requests
     #   sunbeam
-websocket-client==1.7.0
+websocket-client==1.8.0
     # via kubernetes
-websockets==12.0
+websockets==15.0.1
     # via juju
-yarl==1.9.4
+yarl==1.18.3
     # via aiohttp
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
- Bump Juju to 3.6 LTS
- Use a branch of `snap-openstack`, which is a modified version of tag `anvil-0.1`, that uses a bumped Juju python lib to 3.6
- Update Python dependencies to pin to versions related to Juju python lib 3.6
- Pin GH runners to jammy since `ubuntu-latest` is pointing to Noble now, it is using a newer Python and it is breaking pip installation due to different dependency versions

