### PR TITLE
chore: maas-anvil on arm64

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -76,30 +76,29 @@ jobs:
         if: ${{ failure() && runner.debug }}
         uses: canonical/action-tmate@main
 
-  # TODO (@skatsaounis): Uncomment when arm64 installation is supported
-  # functional-test-arm64:
-  #   needs: build-arm64
-  #   name: Functional test
-  #   runs-on: [self-hosted, large, ARM64]
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #     - name: Download snap artifact
-  #       id: download
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: local-${{ needs.build-arm64.outputs.snap }}
-  #     - name: test
-  #       run: |
-  #         export COLUMNS=256
-  #         sudo snap install ${{ needs.build-arm64.outputs.snap }} --dangerous
-  #         maas-anvil prepare-node-script | bash -x
-  #         sg snap_daemon "maas-anvil -v cluster bootstrap --role database --role region --role agent --role haproxy --accept-defaults"
-  #     - name: Collect juju status
-  #       if: always()
-  #       run: |
-  #         juju status
-  #         juju debug-log --replay
-  #     - name: Setup tmate session
-  #       if: ${{ failure() && runner.debug }}
-  #       uses: canonical/action-tmate@main
+  functional-test-arm64:
+    needs: build-arm64
+    name: Functional test
+    runs-on: [self-hosted, large, noble, ARM64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download snap artifact
+        id: download
+        uses: actions/download-artifact@v4
+        with:
+          name: local-${{ needs.build-arm64.outputs.snap }}
+      - name: test
+        run: |
+          export COLUMNS=256
+          sudo snap install ${{ needs.build-arm64.outputs.snap }} --dangerous
+          maas-anvil prepare-node-script | bash -x
+          sg snap_daemon "maas-anvil -v cluster bootstrap --role database --role region --role agent --role haproxy --accept-defaults"
+      - name: Collect juju status
+        if: always()
+        run: |
+          juju status
+          juju debug-log --replay
+      - name: Setup tmate session
+        if: ${{ failure() && runner.debug }}
+        uses: canonical/action-tmate@main

--- a/anvil-python/anvil/commands/haproxy.py
+++ b/anvil-python/anvil/commands/haproxy.py
@@ -31,6 +31,7 @@ from sunbeam.jobs.steps import (
 
 from anvil.jobs.manifest import Manifest
 from anvil.jobs.steps import RemoveMachineUnitStep
+from anvil.utils import get_architecture
 
 LOG = logging.getLogger(__name__)
 
@@ -249,6 +250,9 @@ class DeployHAProxyApplicationStep(DeployMachineApplicationStep):
         variables.pop("ssl_cert", "")
         variables.pop("ssl_key", "")
         variables.pop("ssl_cacert", "")
+
+        if get_architecture() == "arm64":
+            variables["arch"] = "arm64"
 
         LOG.debug(f"extra tfvars: {variables}")
         return variables

--- a/anvil-python/anvil/commands/maas_agent.py
+++ b/anvil-python/anvil/commands/maas_agent.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import Any, List
 
 from sunbeam.clusterd.client import Client
 from sunbeam.commands.terraform import TerraformInitStep
@@ -26,6 +26,7 @@ from sunbeam.jobs.steps import (
 
 from anvil.jobs.manifest import Manifest
 from anvil.jobs.steps import RemoveMachineUnitStep
+from anvil.utils import get_architecture
 
 APPLICATION = "maas-agent"
 CONFIG_KEY = "TerraformVarsMaasagentPlan"
@@ -64,6 +65,12 @@ class DeployMAASAgentApplicationStep(DeployMachineApplicationStep):
 
     def get_application_timeout(self) -> int:
         return MAASAGENT_APP_TIMEOUT
+
+    def extra_tfvars(self) -> dict[str, Any]:
+        variables: dict[str, Any] = {}
+        if get_architecture() == "arm64":
+            variables["arch"] = "arm64"
+        return variables
 
 
 class AddMAASAgentUnitsStep(AddMachineUnitsStep):

--- a/anvil-python/anvil/commands/maas_region.py
+++ b/anvil-python/anvil/commands/maas_region.py
@@ -35,6 +35,7 @@ from sunbeam.jobs.steps import (
 from anvil.commands.haproxy import HAPROXY_CONFIG_KEY, tls_questions
 from anvil.jobs.manifest import Manifest
 from anvil.jobs.steps import RemoveMachineUnitStep
+from anvil.utils import get_architecture
 
 LOG = logging.getLogger(__name__)
 
@@ -156,6 +157,8 @@ class DeployMAASRegionApplicationStep(DeployMachineApplicationStep):
             if answers["ssl_cacert"]:
                 with open(answers["ssl_cacert"]) as cacert_file:
                     variables["ssl_cacert_content"] = cacert_file.read()
+        if get_architecture() == "arm64":
+            variables["arch"] = "arm64"
         return variables
 
 

--- a/anvil-python/anvil/commands/postgresql.py
+++ b/anvil-python/anvil/commands/postgresql.py
@@ -29,6 +29,7 @@ from sunbeam.jobs.steps import (
 
 from anvil.jobs.manifest import Manifest
 from anvil.jobs.steps import RemoveMachineUnitStep
+from anvil.utils import get_architecture
 
 LOG = logging.getLogger(__name__)
 APPLICATION = "postgresql"
@@ -172,6 +173,8 @@ class DeployPostgreSQLApplicationStep(DeployMachineApplicationStep):
         variables["maas_region_nodes"] = len(
             self.client.cluster.list_nodes_by_role("region")
         )
+        if get_architecture() == "arm64":
+            variables["arch"] = "arm64"
         return variables
 
     def has_prompts(self) -> bool:
@@ -226,6 +229,8 @@ class ReapplyPostgreSQLTerraformPlanStep(DeployMachineApplicationStep):
         variables["maas_region_nodes"] = len(
             self.client.cluster.list_nodes_by_role("region")
         )
+        if get_architecture() == "arm64":
+            variables["arch"] = "arm64"
         return variables
 
     def is_skip(self, status: Status | None = None) -> Result:

--- a/anvil-python/anvil/utils.py
+++ b/anvil-python/anvil/utils.py
@@ -15,6 +15,7 @@
 
 import inspect
 import logging
+import platform
 import sys
 from typing import Protocol
 
@@ -185,3 +186,17 @@ class FormatCommandGroupsGroup(click.Group):
                     group_commands, col_max=max_length, col_spacing=2
                 )
                 formatter.dedent()
+
+
+def get_architecture() -> str:
+    """
+    Returns a string identifying the system architecture as 'amd64', 'arm64', or 'other'.
+    """
+    arch: str = platform.machine().lower()
+
+    if arch in ("x86_64", "amd64"):
+        return "amd64"
+    elif arch in ("aarch64", "arm64"):
+        return "arm64"
+    else:
+        return "other"

--- a/cloud/etc/deploy-haproxy/main.tf
+++ b/cloud/etc/deploy-haproxy/main.tf
@@ -55,6 +55,10 @@ resource "juju_application" "haproxy" {
     local.ssl_key,
     var.charm_haproxy_config,
   )
+
+  constraints = join(" ", [
+    "arch=${var.arch}",
+  ])
 }
 
 resource "juju_application" "keepalived" {
@@ -75,6 +79,10 @@ resource "juju_application" "keepalived" {
     local.virtual_ip,
     var.charm_keepalived_config,
   )
+
+  constraints = join(" ", [
+    "arch=${var.arch}",
+  ])
 }
 
 resource "juju_integration" "maas-region-haproxy" {

--- a/cloud/etc/deploy-haproxy/variables.tf
+++ b/cloud/etc/deploy-haproxy/variables.tf
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+variable "arch" {
+  description = "The system architecture of the cluster nodes"
+  type        = string
+  default     = "amd64"
+}
+
 variable "charm_haproxy_channel" {
   description = "Operator channel for HAProxy deployment"
   type        = string

--- a/cloud/etc/deploy-maas-agent/main.tf
+++ b/cloud/etc/deploy-maas-agent/main.tf
@@ -43,6 +43,10 @@ resource "juju_application" "maas-agent" {
   }
 
   config = var.charm_maas_agent_config
+
+  constraints = join(" ", [
+    "arch=${var.arch}",
+  ])
 }
 
 resource "juju_integration" "maas-agent-region" {

--- a/cloud/etc/deploy-maas-agent/variables.tf
+++ b/cloud/etc/deploy-maas-agent/variables.tf
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+variable "arch" {
+  description = "The system architecture of the cluster nodes"
+  type        = string
+  default     = "amd64"
+}
+
 variable "charm_maas_agent_channel" {
   description = "Operator channel for MAAS Agent deployment"
   type        = string

--- a/cloud/etc/deploy-maas-region/main.tf
+++ b/cloud/etc/deploy-maas-region/main.tf
@@ -56,6 +56,10 @@ resource "juju_application" "maas-region" {
     local.ssl_cacert_content,
     var.charm_maas_region_config,
   )
+
+  constraints = join(" ", [
+    "arch=${var.arch}",
+  ])
 }
 
 resource "juju_integration" "maas-region-postgresql" {

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+variable "arch" {
+  description = "The system architecture of the cluster nodes"
+  type        = string
+  default     = "amd64"
+}
+
 variable "charm_maas_region_channel" {
   description = "Operator channel for MAAS Region Controller deployment"
   type        = string

--- a/cloud/etc/deploy-postgresql/main.tf
+++ b/cloud/etc/deploy-postgresql/main.tf
@@ -58,4 +58,8 @@ resource "juju_application" "postgresql" {
     { "plugin_audit_enable" : false },
     var.charm_postgresql_config
   )
+
+  constraints = join(" ", [
+    "arch=${var.arch}",
+  ])
 }

--- a/cloud/etc/deploy-postgresql/variables.tf
+++ b/cloud/etc/deploy-postgresql/variables.tf
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+variable "arch" {
+  description = "The system architecture of the cluster nodes"
+  type        = string
+  default     = "amd64"
+}
+
 variable "charm_postgresql_channel" {
   description = "Operator channel for PostgreSQL deployment"
   type        = string


### PR DESCRIPTION
- Enable maas-anvil functional tests against arm64 runners
- Add a function to detect the architecture of the MAAS node to be provided as a constraint to Juju. Juju cannot automatically install the charm for the proper architecture.
- Pass detected architecture to Juju Terraform plans