### PR TITLE
fix: pin PostgreSQL revision to the newest succesful one known

### DIFF
--- a/anvil-python/anvil/commands/postgresql.py
+++ b/anvil-python/anvil/commands/postgresql.py
@@ -18,10 +18,9 @@ from typing import Any, List
 
 from rich.status import Status
 from sunbeam.clusterd.client import Client
-from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.commands.terraform import TerraformInitStep
 from sunbeam.jobs import questions
-from sunbeam.jobs.common import BaseStep, Result, ResultType, read_config
+from sunbeam.jobs.common import BaseStep, Result, ResultType
 from sunbeam.jobs.juju import JujuHelper
 from sunbeam.jobs.steps import (
     AddMachineUnitsStep,
@@ -31,7 +30,6 @@ from sunbeam.jobs.steps import (
 from anvil.jobs.manifest import Manifest
 from anvil.jobs.steps import RemoveMachineUnitStep
 from anvil.utils import get_architecture
-from anvil.versions import POSTGRESQL_CHANNEL
 
 LOG = logging.getLogger(__name__)
 APPLICATION = "postgresql"
@@ -175,22 +173,8 @@ class DeployPostgreSQLApplicationStep(DeployMachineApplicationStep):
         variables["maas_region_nodes"] = len(
             self.client.cluster.list_nodes_by_role("region")
         )
-        arch = get_architecture()
-        if arch == "arm64":
+        if get_architecture() == "arm64":
             variables["arch"] = "arm64"
-
-        try:
-            tfvars = read_config(self.client, self.config)
-        except ConfigItemNotFoundException:
-            tfvars = {}
-        channel = tfvars.get("charm_postgresql_channel", "")
-        # workaround for: https://bugs.launchpad.net/maas/+bug/2097079, https://github.com/canonical/postgresql-operator/issues/1001
-        if channel == POSTGRESQL_CHANNEL:
-            if arch == "arm64":
-                variables["charm_postgresql_revision"] = 757
-            else:
-                variables["charm_postgresql_revision"] = 758
-
         return variables
 
     def has_prompts(self) -> bool:

--- a/anvil-python/anvil/jobs/manifest.py
+++ b/anvil-python/anvil/jobs/manifest.py
@@ -49,9 +49,11 @@ from sunbeam.jobs.manifest import (
 import yaml
 
 from anvil.jobs.plugin import PluginManager
+from anvil.utils import get_architecture
 from anvil.versions import (
     MANIFEST_ATTRIBUTES_TFVAR_MAP,
     MANIFEST_CHARM_VERSIONS,
+    POSTGRESQL_CHANNEL,
     TERRAFORM_DIR_NAMES,
 )
 
@@ -128,6 +130,12 @@ class SoftwareConfig:
             tfplan: {"source": Path(snap.paths.snap / "etc" / tfplan_dir)}
             for tfplan, tfplan_dir in TERRAFORM_DIR_NAMES.items()
         }
+        # workaround for: https://bugs.launchpad.net/maas/+bug/2097079, https://github.com/canonical/postgresql-operator/issues/1001
+        if POSTGRESQL_CHANNEL == "16/beta":
+            if get_architecture() == "arm64":
+                software["charms"]["postgresql"]["revision"] = 757
+            else:
+                software["charms"]["postgresql"]["revision"] = 758
 
         # Update manifests from plugins
         software_from_plugins = plugin_manager.get_all_plugin_manifests(


### PR DESCRIPTION
- Set default revision for PostgreSQL charm based on architecture
- This new default PostgreSQL charm revision is pinned to the last known successful revision, based on previous GH action runs 
- `base_python` variable corrected for testenv in tox.ini

Resolves: #101 