### PR TITLE
fix: 103 remove keepalived constraint

### DIFF
--- a/cloud/etc/deploy-haproxy/main.tf
+++ b/cloud/etc/deploy-haproxy/main.tf
@@ -80,9 +80,6 @@ resource "juju_application" "keepalived" {
     var.charm_keepalived_config,
   )
 
-  constraints = join(" ", [
-    "arch=${var.arch}",
-  ])
 }
 
 resource "juju_integration" "maas-region-haproxy" {


### PR DESCRIPTION
Removes constraint preventing the deployment of haproxy when VIP is specified. This has not been tested due to edge currently failing to deploy.

Resolves: #103 