### PR TITLE
feat: Introduce s3 relation for MAAS-region

### DIFF
--- a/anvil-python/anvil/versions.py
+++ b/anvil-python/anvil/versions.py
@@ -48,6 +48,11 @@ DEPLOY_MAAS_REGION_TFVAR_MAP = {
             "revision": "charm_maas_region_revision",
             "config": "charm_maas_region_config",
         },
+        "s3-integrator": {
+            "channel": "charm_s3_integrator_channel",
+            "revision": "charm_s3_integrator_revision",
+            "config": "charm_s3_integrator_config",
+        },
     }
 }
 

--- a/cloud/etc/deploy-maas-region/main.tf
+++ b/cloud/etc/deploy-maas-region/main.tf
@@ -35,6 +35,18 @@ locals {
   ssl_cert_content   = var.ssl_cert_content != "" ? { ssl_cert_content = var.ssl_cert_content } : {}
   ssl_key_content    = var.ssl_key_content != "" ? { ssl_key_content = var.ssl_key_content } : {}
   ssl_cacert_content = var.ssl_cacert_content != "" ? { ssl_cacert_content = var.ssl_cacert_content } : {}
+
+  s3_config = merge(
+    {
+      "endpoint" = coalesce(var.endpoint, "https://s3.${var.region}.amazonaws.com")
+      "bucket"   = var.bucket
+      "path"     = "/postgresql"
+      "region"   = var.region
+    },
+    var.charm_s3_integrator_config,
+  )
+
+  s3_enabled = var.s3_enabled ? 1 : 0
 }
 
 resource "juju_application" "maas-region" {
@@ -88,5 +100,67 @@ resource "juju_integration" "maas-region-haproxy" {
   application {
     name     = "haproxy"
     endpoint = "reverseproxy"
+  }
+}
+
+# Configure S3 if desired
+resource "juju_secret" "s3_credentials" {
+  count = local.s3_enabled
+
+  model = data.juju_model.machine_model.name
+  name  = "s3_credentials"
+
+  value = {
+    "access-key" = var.access_key
+    "secret-key" = var.secret_key
+  }
+  info = "Credentials used to access S3"
+}
+
+resource "juju_application" "s3_integrator" {
+  count = local.s3_enabled
+
+  name  = "s3-integrator"
+  model = data.juju_model.machine_model.name
+
+  # TODO: This one should go away when we move out of manual cloud
+#   placement = "0"
+
+  charm {
+    name     = "s3-integrator"
+    channel  = var.charm_s3_integrator_channel
+    revision = var.charm_s3_integrator_revision
+    base     = "ubuntu@24.04"
+  }
+
+  config = merge(
+    local.s3_config,
+    { "credentials" = "secret:${juju_secret.s3_credentials[0].secret_id}" },
+  )
+
+  constraints = "arch=${var.arch}"
+}
+
+resource "juju_access_secret" "s3_credentials" {
+  count = local.s3_enabled
+
+  model        = data.juju_model.machine_model.name
+  applications = [juju_application.s3_integrator[0].name]
+  secret_id    = juju_secret.s3_credentials[0].secret_id
+}
+
+resource "juju_integration" "postgresql_s3_integration" {
+  count = local.s3_enabled
+
+  model = data.juju_model.machine_model.name
+
+  application {
+    name     = juju_application.s3_integrator[0].name
+    endpoint = "s3-credentials"
+  }
+
+  application {
+    name     = juju_application.maas-region.name
+    endpoint = "s3-parameters"
   }
 }

--- a/cloud/etc/deploy-maas-region/main.tf
+++ b/cloud/etc/deploy-maas-region/main.tf
@@ -124,10 +124,10 @@ resource "juju_application" "s3_integrator" {
   model = data.juju_model.machine_model.name
 
   # TODO: This one should go away when we move out of manual cloud
-#   placement = "0"
+  placement = "0"
 
   charm {
-    name     = "s3-integrator"
+    name     = "s3-integrator-region"
     channel  = var.charm_s3_integrator_channel
     revision = var.charm_s3_integrator_revision
     base     = "ubuntu@24.04"
@@ -149,7 +149,7 @@ resource "juju_access_secret" "s3_credentials" {
   secret_id    = juju_secret.s3_credentials[0].secret_id
 }
 
-resource "juju_integration" "postgresql_s3_integration" {
+resource "juju_integration" "maas_region_s3_integration" {
   count = local.s3_enabled
 
   model = data.juju_model.machine_model.name

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -77,3 +77,60 @@ variable "ssl_cacert_content" {
   type        = string
   default     = ""
 }
+
+variable "charm_s3_integrator_channel" {
+  description = "Operator channel for S3 Integrator deployment"
+  type        = string
+  default     = "2/edge"
+}
+
+variable "charm_s3_integrator_revision" {
+  description = "Operator channel revision for S3 Integrator deployment"
+  type        = number
+  # default     = null
+  # This version contains: https://github.com/canonical/object-storage-integrators/pull/36
+  default = 165
+}
+
+variable "charm_s3_integrator_config" {
+  description = "Operator config for S3 Integrator deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "s3_enabled" {
+  description = "Whether we should enable s3 integration"
+  type        = bool
+  default     = false
+}
+
+variable "access_key" {
+  description = "Access key used to access the S3 backup bucket"
+  type        = string
+  default     = ""
+}
+
+variable "secret_key" {
+  description = "Secret key used to access the S3 backup bucket"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "endpoint" {
+  description = "Endpoint the S3 backup exists at. Leave empty to derive endpoint from region: `https://s3.{region}.amazonaws.com`"
+  type        = string
+  default     = ""
+}
+
+variable "bucket" {
+  description = "Bucket name to store PostgreSQL backups in"
+  type        = string
+  default     = ""
+}
+
+variable "region" {
+  description = "The AWS region the S3 bucket is in"
+  type        = string
+  default     = ""
+}

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -101,36 +101,36 @@ variable "charm_s3_integrator_config" {
 variable "s3_enabled" {
   description = "Whether we should enable s3 integration"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "access_key" {
   description = "Access key used to access the S3 backup bucket"
   type        = string
-  default     = "admin"
+  default     = ""
 }
 
 variable "secret_key" {
   description = "Secret key used to access the S3 backup bucket"
   type        = string
   sensitive   = true
-  default     = "password"
+  default     = ""
 }
 
 variable "endpoint" {
   description = "Endpoint the S3 backup exists at. Leave empty to derive endpoint from region: `https://s3.{region}.amazonaws.com`"
   type        = string
-  default     = "https://10.10.0.27:9000"
+  default     = ""
 }
 
 variable "bucket" {
   description = "Bucket name to store PostgreSQL backups in"
   type        = string
-  default     = "anvil"
+  default     = ""
 }
 
 variable "region" {
   description = "The AWS region the S3 bucket is in"
   type        = string
-  default     = "anvil"
+  default     = ""
 }

--- a/cloud/etc/deploy-maas-region/variables.tf
+++ b/cloud/etc/deploy-maas-region/variables.tf
@@ -28,7 +28,7 @@ variable "charm_maas_region_channel" {
 variable "charm_maas_region_revision" {
   description = "Operator channel revision for MAAS Region Controller deployment"
   type        = number
-  default     = null
+  default     = 149
 }
 
 variable "charm_maas_region_config" {
@@ -101,36 +101,36 @@ variable "charm_s3_integrator_config" {
 variable "s3_enabled" {
   description = "Whether we should enable s3 integration"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "access_key" {
   description = "Access key used to access the S3 backup bucket"
   type        = string
-  default     = ""
+  default     = "admin"
 }
 
 variable "secret_key" {
   description = "Secret key used to access the S3 backup bucket"
   type        = string
   sensitive   = true
-  default     = ""
+  default     = "password"
 }
 
 variable "endpoint" {
   description = "Endpoint the S3 backup exists at. Leave empty to derive endpoint from region: `https://s3.{region}.amazonaws.com`"
   type        = string
-  default     = ""
+  default     = "https://10.10.0.27:9000"
 }
 
 variable "bucket" {
   description = "Bucket name to store PostgreSQL backups in"
   type        = string
-  default     = ""
+  default     = "anvil"
 }
 
 variable "region" {
   description = "The AWS region the S3 bucket is in"
   type        = string
-  default     = ""
+  default     = "anvil"
 }

--- a/cloud/etc/deploy-postgresql/main.tf
+++ b/cloud/etc/deploy-postgresql/main.tf
@@ -93,7 +93,7 @@ resource "juju_secret" "s3_credentials" {
 resource "juju_application" "s3_integrator" {
   count = local.s3_enabled
 
-  name  = "s3-integrator"
+  name  = "s3-integrator-postgresql"
   model = data.juju_model.machine_model.name
 
   # TODO: This one should go away when we move out of manual cloud


### PR DESCRIPTION
- Adds a new integration for MAAS-region with the S3-integrator charm.

A new unit with it's own configuration set is co-located with the MAAS-region, rather than re-using the PostgreSQL S3-integrator unit.

Requires the newest revision of the MAAS region charm that includes the relation, which is currently unreleased